### PR TITLE
Free GPU memory during perplexity evaluation

### DIFF
--- a/experiments/run_slicegpt_perplexity.py
+++ b/experiments/run_slicegpt_perplexity.py
@@ -1,8 +1,8 @@
 import argparse
 
 import torch
-import wandb
 
+import wandb
 from slicegpt import datautils, hf_utils, layernorm_fusion, opt_utils, rotate
 
 DEV = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/experiments/run_zero_shot_tasks.py
+++ b/experiments/run_zero_shot_tasks.py
@@ -2,11 +2,11 @@ import argparse
 import json
 
 import torch
-import wandb
 from lm_eval import evaluator, tasks, utils
 from lm_eval.base import BaseLM
 from transformers import AutoTokenizer, OPTForCausalLM
 
+import wandb
 from slicegpt import datautils, layernorm_fusion, rotate, utils
 
 DEV = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/src/slicegpt/opt_utils.py
+++ b/src/slicegpt/opt_utils.py
@@ -44,8 +44,8 @@ def evaluate_perplexity(model, testloader, device):
         print(f", {i}", end="", flush=True)
         layer = layer.to(device)
         outs = [layer(X[j].unsqueeze(0), attention_mask=mask)[0] for j in range(num_samples)]
-        
-        # Remove reference to layer from the list
+
+        # Remove the reference to the i-th layer from the list to allow GC to free GPU memory
         layers[i] = None
         del layer
         torch.cuda.empty_cache()


### PR DESCRIPTION
When running perplexity evaluation we accumulated layers in GPU memory. This change fixes the issue and allows to run opt-30b on one GPU.