### PR TITLE
Set model to evaluation mode in the beginning of rotation

### DIFF
--- a/src/slicegpt/rotate.py
+++ b/src/slicegpt/rotate.py
@@ -142,7 +142,8 @@ def slice_head(model, new_embedding_dimension):
 def rotate_and_slice(model, dataloader, new_embedding_dimension, do_slice_head=False):
     """
     Rotate and slice a model, with interleaved slicing and PCA calculations
-    """
+    """ 
+    model.eval()
     dtype = next(iter(model.parameters())).dtype
 
     inps = []
@@ -228,6 +229,7 @@ def rotate(model, dataloader):
     """
     Rotate a model.
     """
+    model.eval()
     dtype = next(iter(model.parameters())).dtype  # Get the dtype of the model.
 
     # List of layers to rotate.
@@ -283,6 +285,7 @@ def rotate(model, dataloader):
 
 
 def slice_rotated_model(model, new_embedding_dimension, do_slice_head=False):
+    model.eval()
 
     # slice embeddings
     slice_embeddings(model, new_embedding_dimension)


### PR DESCRIPTION
The results of ppl evaluation were non-deterministic because after replacing modules and fusing the model it was no longer in evaluation mode. Therefore rotation was happening in a non-eval mode and results were different.
