### PR TITLE
Use dash in command line args

### DIFF
--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -39,7 +39,7 @@ def argparser():
         default="facebook/opt-125m",
     )
     parser.add_argument(
-        "--eval_dataset",
+        "--eval-dataset",
         type=str,
         help="Dataset to evaluate on.",
         choices=["wikitext2", "ptb", "c4"],
@@ -51,23 +51,25 @@ def argparser():
         help="Number of tokens to benchmark over.",
         default=128,
     )
-    parser.add_argument("--batch_size", type=int, default=1, help="Batch size for loading the calibration data.")
+    parser.add_argument("--batch-size", type=int, default=1, help="Batch size for loading the calibration data.")
     parser.add_argument("--seed", type=int, default=42, help="Seed for sampling the calibration data.")
     parser.add_argument(
-        "--sparsity", type=float, default=0.0, help="A measure of how much slicing is applied (in the range [0, 1])"
+        "--sparsity", type=float, default=0.0, help="A measure of how much slicing is applied (in the range [0, 1))"
     )
     parser.add_argument(
-        "--distribute_model",
+        "--distribute-model",
         action="store_true",
         help="Use accelerate to put the model on multiple GPUs for evaluation. It is recommended to use it for models with 30B parameters and above.",
     )
 
-    parser.add_argument("--load_model_path", type=str, default=None, help="Path to load the sliced model from.")
+    parser.add_argument("--load-model-path", type=str, default=None, help="Path to load the sliced model from.")
 
-    parser.add_argument('--hf_token', type=str, default=None)
+    parser.add_argument('--hf-token', type=str, default=None)
 
     args = parser.parse_args()
-    assert args.sparsity >= 0 and args.sparsity <= 1, "Sparsity should be in the range [0, 1]!"
+
+    if not 0 <= args.sparsity < 1:
+        raise argparse.ArgumentTypeError(f"Sparsity should be in the range [0, 1)")
 
     return args
 

--- a/experiments/run_slicegpt_perplexity.py
+++ b/experiments/run_slicegpt_perplexity.py
@@ -39,38 +39,38 @@ def argparser():
         default="facebook/opt-125m",
     )
     parser.add_argument(
-        "--cal_dataset",
+        "--cal-dataset",
         type=str,
         help="Dataset to calibrate on.",
         choices=["wikitext2", "ptb", "c4"],
         default="wikitext2",
     )
     parser.add_argument(
-        "--cal_nsamples",
+        "--cal-nsamples",
         type=int,
         help="Number of samples of the calibration data to load.",
         default=128,
     )
-    parser.add_argument("--batch_size", type=int, default=1, help="Batch size for loading the calibration data.")
+    parser.add_argument("--batch-size", type=int, default=1, help="Batch size for loading the calibration data.")
     parser.add_argument("--seed", type=int, default=42, help="Seed for sampling the calibration data.")
     parser.add_argument(
-        "--sparsity", type=float, default=0.0, help="A measure of how much slicing is applied (in the range [0, 1])"
+        "--sparsity", type=float, default=0.0, help="A measure of how much slicing is applied (in the range [0, 1))"
     )
-    parser.add_argument("--eval_baseline", action="store_true", help="Evaluate the baseline model.")
-    parser.add_argument("--eval_fused_model", action="store_true", help="Evaluate the fused model.")
-    parser.add_argument("--ppl_only", action="store_true", help="Evaluate the loaded model without doing compression.")
+    parser.add_argument("--eval-baseline", action="store_true", help="Evaluate the baseline model.")
+    parser.add_argument("--eval-fused-model", action="store_true", help="Evaluate the fused model.")
+    parser.add_argument("--ppl-only", action="store_true", help="Evaluate the loaded model without doing compression.")
     parser.add_argument(
-        "--distribute_model",
+        "--distribute-model",
         action="store_true",
         help="Use accelerate to put the model on multiple GPUs for evaluation. It is recommended to use it for models with 30B parameters and above.",
     )
 
-    parser.add_argument("--save_dir", type=str, default=None, help="Path to save the model.")
-    parser.add_argument("--load_model_path", type=str, default=None, help="Path to load the sliced model from.")
+    parser.add_argument("--save-dir", type=str, default=None, help="Path to save the model.")
+    parser.add_argument("--load-model-path", type=str, default=None, help="Path to load the sliced model from.")
 
-    parser.add_argument('--hf_token', type=str, default=None)
+    parser.add_argument('--hf-token', type=str, default=None)
 
-    parser.add_argument('--no_wandb', action="store_true", help="Disable wandb.")
+    parser.add_argument('--no-wandb', action="store_true", help="Disable wandb.")
 
     args = parser.parse_args()
 

--- a/experiments/run_zero_shot_tasks.py
+++ b/experiments/run_zero_shot_tasks.py
@@ -136,35 +136,35 @@ def parse_args():
         default="facebook/opt-125m",
     )
     parser.add_argument(
-        "--cal_dataset",
+        "--cal-dataset",
         type=str,
         help="Dataset to calibrate on.",
         choices=["wikitext2", "ptb", "c4"],
         default="wikitext2",
     )
     parser.add_argument(
-        "--cal_nsamples",
+        "--cal-nsamples",
         type=int,
         help="Number of samples of the calibration data to load.",
         default=128,
     )
     parser.add_argument("--tasks", default=None, choices=lm_eval_utils.MultiChoice(tasks.ALL_TASKS))
-    parser.add_argument("--no_cache", action="store_true")
+    parser.add_argument("--no-cache", action="store_true")
     parser.add_argument(
-        "--sparsity", type=float, default=0.0, help="A measure of how much slicing is applied (in the range [0, 1])"
+        "--sparsity", type=float, default=0.0, help="A measure of how much slicing is applied (in the range [0, 1))"
     )
-    parser.add_argument("--batch_size", type=int, default=1, help="Batch size for loading the calibration data.")
+    parser.add_argument("--batch-size", type=int, default=1, help="Batch size for loading the calibration data.")
     parser.add_argument(
-        "--distribute_model",
+        "--distribute-model",
         action="store_true",
         help="Use accelerate to put the model on multiple GPUs for evaluation. It is recommended to use it for models with 30B parameters and above.",
     )
 
-    parser.add_argument("--load_model_path", type=str, default=None, help="Path to load the sliced model from.")
+    parser.add_argument("--load-model-path", type=str, default=None, help="Path to load the sliced model from.")
 
-    parser.add_argument("--baseline", action="store_true", help="Evalute the dense (un-sliced) model.")
+    parser.add_argument("--baseline", action="store_true", help="Evaluate the dense (un-sliced) model.")
 
-    parser.add_argument('--hf_token', type=str, default=None)
+    parser.add_argument('--hf-token', type=str, default=None)
 
     return parser.parse_args()
 


### PR DESCRIPTION
Use dash in command line arguments instead of underscore (dash is more common).