### PR TITLE
adding rounding option to script

### DIFF
--- a/experiments/run_slicegpt_perplexity.py
+++ b/experiments/run_slicegpt_perplexity.py
@@ -204,7 +204,7 @@ def main() -> None:
     new_embedding_dimension = int((1 - args.sparsity) * model_adapter.hidden_size)
     # round (down) to the nearest multiple of round_interval
     new_embedding_dimension = new_embedding_dimension - (new_embedding_dimension % args.round_interval) 
-    logging.info(f"New embedding dimension: {new_embedding_dimension} (sparsity {100*new_embedding_dimension / model_adapter.hidden_size:.4f} %)")
+    logging.info(f"New embedding dimension: {new_embedding_dimension} (sparsity {100*(1 - new_embedding_dimension / model_adapter.hidden_size):.4f} %)")
 
     ignore_tokens = [tokenizer.pad_token_id]
     rotate.rotate_and_slice(model_adapter, train_loader, new_embedding_dimension, ignore_tokens=ignore_tokens)


### PR DESCRIPTION
When choosing the new embedding dimension, we now default to the nearest multiple of 8. Otherwise perf suffers on h100 machines. 

Slicing opt125m ant 30%, the log now looks like this:
`New embedding dimension: 536 (sparsity 30.2083 %)`