### PR TITLE
Use hf-token from env var or cmd arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ To run sliceGPT on `microsoft/phi-2`, from the `experiments` folder, run
            --device cuda:0 \
            --eval-baseline
 ```
-This will compress the `microsoft/phi-2` model and save the compressed model to the specified directory. Please consult the script for the full set of options.
+This will compress the `microsoft/phi-2` model and save the compressed model to the specified directory. Please consult 
+the script for the full set of options.
 
 The experiments folder also contains scripts for 
 - [finetuning](./experiments/run_finetuning.py) the compressed model to recover most of the quality lost during compression
-- [zero-shot task evaluation](./experiments/run_zero_shot_tasks.py) on a given version of the model (dense, compressed or finetuned)
+- [zero-shot task evaluation](./experiments/run_zero_shot_tasks.py) of a dense, compressed or fine-tuned model
+
+_Note:_ For models that require HuggingFace authentication, set the `--hf-token` argument 
+manually or using a key vault. Alternatively, set the environment variable 'HF_TOKEN'.
 
 ### Supported models
 

--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -65,7 +65,7 @@ def argparser() -> argparse.Namespace:
 
     parser.add_argument("--load-model-path", type=str, default=None, help="Path to load the sliced model from.")
 
-    parser.add_argument('--hf-token', type=str, default=None)
+    parser.add_argument('--hf-token', type=str, default=os.getenv('HF_TOKEN', None))
 
     parser.add_argument('--no-wandb', action="store_true", help="Disable wandb.")
     parser.add_argument(

--- a/experiments/run_finetuning.py
+++ b/experiments/run_finetuning.py
@@ -103,7 +103,7 @@ def argparser():
     parser.add_argument(
         "--load-model-path", type=str, default=None, required=True, help="Path to load the sliced model from."
     )
-    parser.add_argument('--hf-token', type=str, default=None)
+    parser.add_argument('--hf-token', type=str, default=os.getenv('HF_TOKEN', None))
 
     parser.add_argument('--wandb-project', type=str, default="slicegpt-finetuning")
     parser.add_argument('--no-wandb', action="store_true", help="Disable wandb.")

--- a/experiments/run_slicegpt_perplexity.py
+++ b/experiments/run_slicegpt_perplexity.py
@@ -78,7 +78,7 @@ def argparser() -> argparse.Namespace:
     parser.add_argument("--save-dir", type=str, default=None, help="Path to save the model.")
     parser.add_argument("--load-model-path", type=str, default=None, help="Path to load the sliced model from.")
 
-    parser.add_argument('--hf-token', type=str, default=None)
+    parser.add_argument('--hf-token', type=str, default=os.getenv('HF_TOKEN', None))
 
     parser.add_argument('--no-wandb', action="store_true", help="Disable wandb.")
     parser.add_argument(

--- a/experiments/run_zero_shot_tasks.py
+++ b/experiments/run_zero_shot_tasks.py
@@ -51,7 +51,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--sparsity", type=float, default=0.0, help="A measure of how much slicing is applied (in the range [0, 1))"
     )
-    parser.add_argument('--hf-token', type=str, default=None)
+    parser.add_argument('--hf-token', type=str, default=os.getenv('HF_TOKEN', None))
     parser.add_argument("--batch-size", type=int, default=1, help="Batch size for evaluating with lm eval harness.")
     parser.add_argument(
         "--distribute-model",


### PR DESCRIPTION
Use hf-token from env var or cmd arg. Allows None. Issue #58. Tested locally and on AML. This is sufficient for now and does not preclude using a key vault in AML (hopefully the same for other cloud providers). 