### PR TITLE
Fix layers split across GPUs when using --distribute

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
 ]
 
 finetune = [
-    "syne-tune==0.10.0",
+    "syne-tune[gpsearchers]==0.10.0",
     "peft==0.6.0"
 ]
 

--- a/src/slicegpt/adapters/llama_adapter.py
+++ b/src/slicegpt/adapters/llama_adapter.py
@@ -142,7 +142,7 @@ class LlamaModelAdapter(ModelAdapter):
 
     @property
     def no_split_module_classes(self) -> list[str]:
-        return ["LlamaDecoderLayer", "CompressedLlamaDecoderLayer"]
+        return [LlamaDecoderLayer.__name__, CompressibleLlamaDecoderLayer.__name__]
 
     @property
     def seqlen(self) -> int:

--- a/src/slicegpt/adapters/opt_adapter.py
+++ b/src/slicegpt/adapters/opt_adapter.py
@@ -165,7 +165,7 @@ class OPTModelAdapter(ModelAdapter):
 
     @property
     def no_split_module_classes(self) -> list[str]:
-        return ["OPTDecoderLayer", "CompressedOPTDecoderLayer"]
+        return [OPTDecoderLayer.__name__, CompressibleOPTDecoderLayer.__name__]
 
     @property
     def seqlen(self) -> int:

--- a/src/slicegpt/adapters/phi2_adapter.py
+++ b/src/slicegpt/adapters/phi2_adapter.py
@@ -139,7 +139,7 @@ class Phi2ModelAdapter(ModelAdapter):
 
     @property
     def no_split_module_classes(self) -> list[str]:
-        return ["PhiDecoderLayer", "CompressiblePhiDecoderLayer"]
+        return [PhiDecoderLayer.__name__, CompressiblePhiDecoderLayer.__name__]
 
     @property
     def seqlen(self) -> int:


### PR DESCRIPTION
Fixes #66. Many thanks @PocherninaElena for the solution!

Additional fix: add [gpsearchers] for finetuning install requirements in toml.