### PR TITLE
Update llama_adapter.py

### DIFF
--- a/src/slicegpt/adapters/llama_adapter.py
+++ b/src/slicegpt/adapters/llama_adapter.py
@@ -29,7 +29,7 @@ class CompressibleLlamaDecoderLayer(LlamaDecoderLayer):
         past_key_value: tuple[Tensor] | None = None,
         output_attentions: bool | None = False,
         use_cache: bool | None = False,
-        padding_mask: LongTensor | None = None,
+        **kwargs,
     ) -> tuple:
         """
         Args:
@@ -57,7 +57,7 @@ class CompressibleLlamaDecoderLayer(LlamaDecoderLayer):
             past_key_value=past_key_value,
             output_attentions=output_attentions,
             use_cache=use_cache,
-            padding_mask=padding_mask,
+            **kwargs,
         )
         if self.attn_shortcut_Q is not None:
             rotated_residual = matmul(residual, self.attn_shortcut_Q)


### PR DESCRIPTION
Update needed for transformers>=4.37.0.dev0 (current pinned commit). Cosmetic change since `attention_mask` was being used anyway.

Avoids 
```
if "padding_mask" in kwargs:
    warnings.warn(
        "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
    )
```