### PR TITLE
Add varying per layer sparsity

### DIFF
--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -117,7 +117,7 @@ def main() -> None:
         # load the model from load_model_path to compute perplexity and skip rotation and slicing
         logging.info(f"Loading sliced {args.model} model from {args.load_model_path} with sparsity {args.sparsity}")
         model_adapter, tokenizer = hf_utils.load_sliced_model(
-            args.model, args.load_model_path, args.sparsity, args.hf_token
+            args.model, args.load_model_path, sparsity=args.sparsity, token=args.hf_token
         )
     else:
         # load one of the pre-trained models

--- a/experiments/run_finetuning.py
+++ b/experiments/run_finetuning.py
@@ -243,7 +243,11 @@ def main() -> None:
         # load the sliced model
         logging.info(f"Loading sliced {args.model} model from {args.load_model_path} with sparsity {args.sparsity}")
         model_adapter, tokenizer = hf_utils.load_sliced_model(
-            args.model, args.load_model_path, args.sparsity, token=args.hf_token, round_interval=args.round_interval
+            args.model,
+            args.load_model_path,
+            sparsity=args.sparsity,
+            token=args.hf_token,
+            round_interval=args.round_interval,
         )
     else:
         # load the original model

--- a/experiments/run_zero_shot_tasks.py
+++ b/experiments/run_zero_shot_tasks.py
@@ -101,7 +101,11 @@ def main() -> None:
         # load the sliced model
         logging.info(f"Loading sliced {args.model} model from {args.load_model_path} with sparsity {args.sparsity}")
         model_adapter, tokenizer = hf_utils.load_sliced_model(
-            args.model, args.load_model_path, args.sparsity, token=args.hf_token, round_interval=args.round_interval
+            args.model,
+            args.load_model_path,
+            sparsity=args.sparsity,
+            token=args.hf_token,
+            round_interval=args.round_interval,
         )
     else:
         # load the original model

--- a/src/slicegpt/hf_utils.py
+++ b/src/slicegpt/hf_utils.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import logging
+import pathlib
 
 import torch
 from peft import LoraConfig, get_peft_model
@@ -20,7 +21,7 @@ from .adapters.llama_adapter import LlamaModelAdapter
 from .adapters.opt_adapter import OPTModelAdapter
 from .adapters.phi2_adapter import Phi2ModelAdapter
 from .layernorm_fusion import fuse_modules, replace_layers
-from .model_adapter import ModelAdapter
+from .model_adapter import ModelAdapter, SlicingConfig
 from .rotate import slice_rotated_model
 
 
@@ -137,18 +138,17 @@ def get_model_and_tokenizer(
 def load_sliced_model(
     model_name: str,
     model_path: str,
-    sparsity: float,
+    *,
     token: str,
     lora_config: LoraConfig = None,
-    round_interval: int = 1,
+    sparsity: float | None = None,
+    round_interval: int | None = 1,
 ) -> tuple[ModelAdapter, PreTrainedTokenizerBase]:
     """Loads the sliced model and the tokenizer from the given path. If lora_config is supplied as an arg then this
     function will return a PEFT model (post-slicing finetuned model)."""
     model_adapter, tokenizer = get_model_and_tokenizer(model_name, uninitialized=True, token=token)
     replace_layers(model_adapter)
     fuse_modules(model_adapter)
-    new_embedding_dimension = int((1 - sparsity) * model_adapter.hidden_size)
-    new_embedding_dimension = new_embedding_dimension - (new_embedding_dimension % round_interval)
 
     for layer_adapter in model_adapter.get_layers():
         if not model_adapter.parallel_blocks:
@@ -160,7 +160,21 @@ def load_sliced_model(
             dtype=torch.float16
         )
 
-    slice_rotated_model(model_adapter, new_embedding_dimension)
+    model_path = pathlib.Path(model_path)
+    config_path = model_path.with_suffix(".json")
+
+    if config_path.exists():
+        model_adapter.slicing_conf = SlicingConfig.from_json_string(config_path.read_text())
+
+    if model_adapter.slicing_conf is None:
+        # assume the model was sliced with the const sparsity specified in the arguments to this method
+        new_embedding_dimension = int((1 - sparsity) * model_adapter.hidden_size)
+        new_embedding_dimension -= new_embedding_dimension % round_interval
+        config = SlicingConfig()
+        config.const_dimension = new_embedding_dimension
+        model_adapter.slicing_conf = config
+
+    slice_rotated_model(model_adapter)
 
     if lora_config:
         model_adapter.model = get_peft_model(model_adapter.model, lora_config)

--- a/src/slicegpt/model_adapter.py
+++ b/src/slicegpt/model_adapter.py
@@ -298,6 +298,11 @@ class ModelAdapter(ABC):
 class SlicingConfig:
     """Slicing configuration such as individual layer dimensions and whether to slice head."""
 
+    hidden_size: int = 0
+    layers_num: int = 0
+    do_slice_head: bool = False
+    parallel_blocks: bool = False
+
     # use dict[int, int] instead of list[int] to allow for arbitrary order updates and default dicts
     embedding_dimensions: dict[int, int] = field(default_factory=dict)
 
@@ -307,8 +312,7 @@ class SlicingConfig:
     mlp_input_dimensions: dict[int, int] = field(default_factory=dict)
     mlp_output_dimensions: dict[int, int] = field(default_factory=dict)
 
-    head_dimension: int = 0
-    do_slice_head: bool = False
+    head_dimension: int | None = None
 
     const_dimension: int | None = None  # to be able to load models without config, sliced with const sparsity
 

--- a/src/slicegpt/model_adapter.py
+++ b/src/slicegpt/model_adapter.py
@@ -296,7 +296,7 @@ class ModelAdapter(ABC):
 
 @dataclass
 class SlicingConfig:
-    """Slicing configuration such as whether individual layer dimensions and whether to slice head."""
+    """Slicing configuration such as individual layer dimensions and whether to slice head."""
 
     # use dict[int, int] instead of list[int] to allow for arbitrary order updates and default dicts
     embedding_dimensions: dict[int, int] = field(default_factory=dict)

--- a/src/slicegpt/rotate.py
+++ b/src/slicegpt/rotate.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 from .config import config
 from .model_adapter import LayerAdapter, ModelAdapter
 from .model_utils import get_layer0_inputs, get_signals
+from .slicing_scheduler import ConfigSlicingScheduler, ConstSlicingScheduler, SlicingScheduler
 from .utils import cleanup_memory, map_tensors
 
 
@@ -21,7 +22,7 @@ def rotate_attention_inputs(layer_adapter: LayerAdapter, Q: torch.Tensor) -> Non
 
 
 def slice_attention_inputs(layer_adapter: LayerAdapter, new_embedding_dimension: int) -> None:
-    # Slice the  WQ, WK and WV matrices of the self-attention layer.
+    # Slice the WQ, WK and WV matrices of the self-attention layer.
     for W in layer_adapter.get_attention_inputs():
         W.weight.data = W.weight.data[:, :new_embedding_dimension]
         W.in_features = new_embedding_dimension
@@ -96,10 +97,10 @@ def rotate_embeddings(model_adapter: ModelAdapter, Q: torch.Tensor) -> None:
     cleanup_memory()
 
 
-def slice_embeddings(model_adapter: ModelAdapter, new_embedding_dimension: int) -> None:
+def slice_embeddings(model_adapter: ModelAdapter, new_embedding_dimensions: dict[int, int]) -> None:
     # Slice the embeddings.
-    for W in model_adapter.get_embeddings():
-        W.weight.data = W.weight.data[:, :new_embedding_dimension]
+    for i, W in enumerate(model_adapter.get_embeddings()):
+        W.weight.data = W.weight.data[:, : new_embedding_dimensions[i]]
 
 
 def rotate_head(model_adapter: ModelAdapter, Q: torch.Tensor) -> None:
@@ -120,29 +121,27 @@ def slice_head(model_adapter: ModelAdapter, new_embedding_dimension: int) -> Non
 def rotate_and_slice(
     model_adapter: ModelAdapter,
     dataloader: torch.utils.data.DataLoader[torch.Tensor],
-    new_embedding_dimension: int,
-    do_slice_head: bool = False,
+    slicing_scheduler: SlicingScheduler,
     ignore_tokens: list[int] | None = None,
 ) -> None:
     """
     Rotate and slice a model, with interleaved slicing and PCA calculations
     """
     if model_adapter.parallel_blocks:
-        rotate_and_slice_parallel(model_adapter, dataloader, new_embedding_dimension, do_slice_head, ignore_tokens)
+        rotate_and_slice_parallel(model_adapter, dataloader, slicing_scheduler, ignore_tokens)
     else:
-        rotate_and_slice_sequential(model_adapter, dataloader, new_embedding_dimension, do_slice_head, ignore_tokens)
+        rotate_and_slice_sequential(model_adapter, dataloader, slicing_scheduler, ignore_tokens)
 
 
 @torch.no_grad()
 def rotate_and_slice_sequential(
     model_adapter: ModelAdapter,
     dataloader: torch.utils.data.DataLoader[torch.Tensor],
-    new_embedding_dimension: int,
-    do_slice_head: bool = False,
+    slicing_scheduler: SlicingScheduler,
     ignore_tokens: list[int] | None = None,
 ) -> None:
     """
-    Rotate and slice a model, with interleaved slicing and PCA calculations
+    Rotate and slice the provided model, with interleaved slicing and PCA calculations.
 
     This method works for models where the MLP block is computed after the attention block.
     """
@@ -160,40 +159,49 @@ def rotate_and_slice_sequential(
                 torch.stack([batch["input_ids"] == ignore_token for ignore_token in ignore_tokens]).any(dim=0)
             )
 
-    _, Q = pca_calc(inps, ignore_masks)
-    Q = Q.to(device=config.device)
+    layers = model_adapter.get_layers()
+    slicing_scheduler.setup(hidden_size=model_adapter.hidden_size, layers_num=len(layers))
 
+    # rotate and slice embeddings
+    eig_val, Q = pca_calc(inps, ignore_masks)
+    Q = Q.to(device=config.device)
     rotate_embeddings(model_adapter, Q)
-    slice_embeddings(model_adapter, new_embedding_dimension)
+    slice_embeddings(model_adapter, slicing_scheduler.get_embedding_dimensions())
 
     logging.info("Rotate and slice layers")
-    layers = model_adapter.get_layers()
-    for layer_adapter in tqdm(layers, unit="layer", desc="Rotating and slicing"):
+    for idx, layer_adapter in enumerate(tqdm(layers, unit="layer", desc="Rotating and slicing")):
         layer = layer_adapter.layer
         layer.attn_shortcut_Q = Q.T.clone().to(dtype=dtype)
 
         # rotate and slice the attention inputs to match previous layer
         rotate_attention_inputs(layer_adapter, Q)
-        slice_attention_inputs(layer_adapter, new_embedding_dimension)
+        slice_attention_inputs(layer_adapter, slicing_scheduler.get_attention_input_dimension(idx))
 
         # get signal between attention and mlp, rotate and slice
         for i, inp in enumerate(inps):
             args[i] = layer_adapter.get_updated_args(
-                torch.matmul(inp.to(device=config.device), Q.to(dtype=dtype))[:, :, :new_embedding_dimension].cpu(),
+                torch.matmul(inp.to(device=config.device), Q.to(dtype=dtype))[
+                    :, :, : slicing_scheduler.get_attention_input_dimension(idx)
+                ].cpu(),
                 args[i],
             )
 
         mlp_ln_inputs, _ = get_signals(layer_adapter, args, kwargs)
-        _, Q = pca_calc(mlp_ln_inputs, ignore_masks)
+        eig_val, Q = pca_calc(mlp_ln_inputs, ignore_masks)
         Q = Q.to(device=config.device, dtype=torch.float64)
 
-        layer.attn_shortcut_Q = torch.matmul(layer.attn_shortcut_Q, Q.to(dtype=dtype)[:, :new_embedding_dimension])
+        layer.attn_shortcut_Q = torch.matmul(
+            layer.attn_shortcut_Q,
+            Q.to(dtype=dtype)[:, : slicing_scheduler.get_attention_output_dimension(idx, match_head_dim=False)],
+        )
         rotate_attention_output(layer_adapter, Q)
-        slice_attention_output(layer_adapter, new_embedding_dimension)
+        slice_attention_output(
+            layer_adapter, slicing_scheduler.get_attention_output_dimension(idx, match_head_dim=False)
+        )
 
-        layer.mlp_shortcut_Q = Q.T.clone().to(dtype=dtype)[:new_embedding_dimension, :]
+        layer.mlp_shortcut_Q = Q.T.clone().to(dtype=dtype)[: slicing_scheduler.get_mlp_input_dimension(idx), :]
         rotate_mlp_input(layer_adapter, Q)
-        slice_mlp_input(layer_adapter, new_embedding_dimension)
+        slice_mlp_input(layer_adapter, slicing_scheduler.get_mlp_input_dimension(idx))
 
         # Run GC and cleanup GPU memory
         cleanup_memory()
@@ -201,19 +209,14 @@ def rotate_and_slice_sequential(
         # now compute the outputs of the current layer/inputs for the next layer
         # with slicing between Attention and mlp.
         _, inps = get_signals(layer_adapter, args, kwargs)
-        _, Q = pca_calc(inps, ignore_masks)
+        eig_val, Q = pca_calc(inps, ignore_masks)
 
         layer.mlp_shortcut_Q = torch.matmul(layer.mlp_shortcut_Q, Q.to(dtype=dtype))
 
         # optionally slice the mlp/head connection in the last layer
-        dim = new_embedding_dimension
-        if layer_adapter is layers[-1]:
-            if not do_slice_head:
-                dim = model_adapter.hidden_size
-
         rotate_mlp_output(layer_adapter, Q)
-        slice_mlp_output(layer_adapter, dim)
-        layer_adapter.layer.mlp_shortcut_Q = layer_adapter.layer.mlp_shortcut_Q[:, :dim]
+        slice_mlp_output(layer_adapter, slicing_scheduler.get_mlp_output_dimension(idx))
+        layer.mlp_shortcut_Q = layer.mlp_shortcut_Q[:, : slicing_scheduler.get_mlp_output_dimension(idx)]
 
         layer.to('cpu')
 
@@ -222,9 +225,11 @@ def rotate_and_slice_sequential(
 
     # rotate and slice head
     rotate_head(model_adapter, Q)
-    if do_slice_head:
-        slice_head(model_adapter, new_embedding_dimension)
+    if slicing_scheduler.do_slice_head:
+        slice_head(model_adapter, slicing_scheduler.get_head_dimension())
 
+    # update model's slicing config
+    model_adapter.slicing_conf = slicing_scheduler.slicing_conf.clone()
     logging.info("Rotate and slice layers done")
 
 
@@ -232,8 +237,7 @@ def rotate_and_slice_sequential(
 def rotate_and_slice_parallel(
     model_adapter: ModelAdapter,
     dataloader: torch.utils.data.DataLoader[torch.Tensor],
-    new_embedding_dimension: int,
-    do_slice_head: bool = False,
+    slicing_scheduler: SlicingScheduler,
     ignore_tokens: list[int] | None = None,
 ) -> None:
     """
@@ -255,28 +259,33 @@ def rotate_and_slice_parallel(
                 torch.stack([batch["input_ids"] == ignore_token for ignore_token in ignore_tokens]).any(dim=0)
             )
 
+    layers = model_adapter.get_layers()
+    slicing_scheduler.setup(hidden_size=model_adapter.hidden_size, layers_num=len(layers))
+
+    # rotate and slice embeddings
     _, Q = pca_calc(inps, ignore_masks)
     Q = Q.to(device=config.device)
-
     rotate_embeddings(model_adapter, Q)
-    slice_embeddings(model_adapter, new_embedding_dimension)
+    slice_embeddings(model_adapter, slicing_scheduler.get_embedding_dimensions())
 
     logging.info("Rotate and slice layers")
     layers = model_adapter.get_layers()
-    for layer_adapter in tqdm(layers, unit="layer", desc="Rotating and slicing"):
+    for idx, layer_adapter in enumerate(tqdm(layers, unit="layer", desc="Rotating and slicing")):
         layer = layer_adapter.layer
         layer.attn_shortcut_Q = Q.T.clone().to(dtype=dtype)
 
         # rotate and slice the inputs to match previous layer (both attention and mlp)
         rotate_attention_inputs(layer_adapter, Q)
         rotate_mlp_input(layer_adapter, Q)
-        slice_attention_inputs(layer_adapter, new_embedding_dimension)
-        slice_mlp_input(layer_adapter, new_embedding_dimension)
+        slice_attention_inputs(layer_adapter, slicing_scheduler.get_attention_input_dimension(idx))
+        slice_mlp_input(layer_adapter, slicing_scheduler.get_attention_input_dimension(idx))
 
         # update the input signals to this layer, and re-run it
         for i, inp in enumerate(inps):
             args[i] = layer_adapter.get_updated_args(
-                torch.matmul(inp.to(device=config.device), Q.to(dtype=dtype))[:, :, :new_embedding_dimension].cpu(),
+                torch.matmul(inp.to(device=config.device), Q.to(dtype=dtype))[
+                    :, :, : slicing_scheduler.get_attention_input_dimension(idx)
+                ].cpu(),
                 args[i],
             )
 
@@ -296,22 +305,17 @@ def rotate_and_slice_parallel(
         inps = outputs
         _, Q = pca_calc(inps, ignore_masks)
 
-        # update shorcut matrix
+        # update shortcut matrix
         layer.attn_shortcut_Q = torch.matmul(layer.attn_shortcut_Q, Q.to(dtype=dtype))
 
         # optionally slice the mlp/head connection in the last layer
-        dim = new_embedding_dimension
-        if layer_adapter is layers[-1]:
-            if not do_slice_head:
-                dim = model_adapter.hidden_size
-
         rotate_mlp_output(layer_adapter, Q)
         rotate_attention_output(layer_adapter, Q)
-        slice_mlp_output(layer_adapter, dim)
-        slice_attention_output(layer_adapter, dim)
+        slice_mlp_output(layer_adapter, slicing_scheduler.get_mlp_output_dimension(idx))
+        slice_attention_output(layer_adapter, slicing_scheduler.get_mlp_output_dimension(idx))
 
         # slice the shortcut (there is only one, we use attn_shortcut buffer)
-        layer.attn_shortcut_Q = layer.attn_shortcut_Q[:new_embedding_dimension, :dim]
+        layer.attn_shortcut_Q = layer.attn_shortcut_Q[:, : slicing_scheduler.get_mlp_output_dimension(idx)]
 
         layer.to('cpu')
 
@@ -320,9 +324,11 @@ def rotate_and_slice_parallel(
 
     # rotate and slice head
     rotate_head(model_adapter, Q)
-    if do_slice_head:
-        slice_head(model_adapter, new_embedding_dimension)
+    if slicing_scheduler.do_slice_head:
+        slice_head(model_adapter, slicing_scheduler.get_head_dimension())
 
+    # update model's slicing config
+    model_adapter.slicing_conf = slicing_scheduler.slicing_conf.clone()
     logging.info("Rotate and slice layers done")
 
 
@@ -393,45 +399,60 @@ def rotate(model_adapter: ModelAdapter, dataloader: torch.utils.data.DataLoader[
     logging.info("Rotate layers done")
 
 
-def slice_rotated_model(model_adapter: ModelAdapter, new_embedding_dimension: int, do_slice_head: bool = False) -> None:
+def slice_rotated_model(model_adapter: ModelAdapter, slicing_scheduler: SlicingScheduler | None = None) -> None:
     """
     TODO: Make this gpu memory efficient.
     """
     model_adapter.model.eval()
+    layers = model_adapter.get_layers()
+    if not slicing_scheduler:
+        if model_adapter.slicing_conf.const_dimension is not None:
+            # backward compatibility for when no config is available
+            slicing_scheduler = ConstSlicingScheduler(model_adapter.slicing_conf.const_dimension)
+        else:
+            slicing_scheduler = ConfigSlicingScheduler(model_adapter.slicing_conf)
+    slicing_scheduler.setup(hidden_size=model_adapter.hidden_size, layers_num=len(layers))
 
     # slice embeddings
-    slice_embeddings(model_adapter, new_embedding_dimension)
+    slice_embeddings(model_adapter, slicing_scheduler.get_embedding_dimensions())
 
-    # List of layers to sice.
-    layers = model_adapter.get_layers()
-
-    for layer_adapter in layers:
+    # slice layers
+    for i, layer_adapter in enumerate(layers):
         layer = layer_adapter.layer
-        slice_attention_inputs(layer_adapter, new_embedding_dimension)
+        # slice attn weights 2nd dim, attn shortcut 1st dim
+        slice_attention_inputs(layer_adapter, slicing_scheduler.get_attention_input_dimension(i))
 
-        slice_mlp_input(layer_adapter, new_embedding_dimension)
+        # slice mlp input 2nd dimension
+        slice_mlp_input(layer_adapter, slicing_scheduler.get_mlp_input_dimension(i))
 
+        # slice mlp shortcut 1st dimension
         # slice mlp shortcut
-        if not model_adapter.parallel_blocks:
-            layer_adapter.layer.mlp_shortcut_Q = layer_adapter.layer.mlp_shortcut_Q[:new_embedding_dimension, :]
+        if layer.mlp_shortcut_Q is not None:
+            layer.mlp_shortcut_Q = layer.mlp_shortcut_Q[: slicing_scheduler.get_mlp_input_dimension(i), :]
 
-        # optionally slice the mlp/head connection in the last layer
-        dim = new_embedding_dimension
-        if layer_adapter is layers[-1]:
-            if not do_slice_head:
-                dim = model_adapter.hidden_size
+        # slice mlp weights 1st dimension
+        slice_mlp_output(layer_adapter, slicing_scheduler.get_mlp_output_dimension(i))
 
-        slice_mlp_output(layer_adapter, dim)
-        if model_adapter.parallel_blocks:  # parallel case
-            layer.attn_shortcut_Q = layer.attn_shortcut_Q[:new_embedding_dimension, :dim]
-            slice_attention_output(layer_adapter, dim)
+        if layer.mlp_shortcut_Q is None:  # parallel case
+            layer.attn_shortcut_Q = layer.attn_shortcut_Q[
+                :, : slicing_scheduler.get_attention_output_dimension(i, match_head_dim=True)
+            ]
+            slice_attention_output(
+                layer_adapter, slicing_scheduler.get_attention_output_dimension(i, match_head_dim=True)
+            )
         else:  # sequential case
-            layer.attn_shortcut_Q = layer.attn_shortcut_Q[:new_embedding_dimension, :new_embedding_dimension]
-            layer.mlp_shortcut_Q = layer.mlp_shortcut_Q[:new_embedding_dimension, :dim]
-            slice_attention_output(layer_adapter, new_embedding_dimension)
+            layer.attn_shortcut_Q = layer.attn_shortcut_Q[
+                :, : slicing_scheduler.get_attention_output_dimension(i, match_head_dim=False)
+            ]
+            layer.mlp_shortcut_Q = layer.mlp_shortcut_Q[:, : slicing_scheduler.get_mlp_output_dimension(i)]
 
-    if do_slice_head:
-        slice_head(model_adapter, new_embedding_dimension)
+            # slice attention weights 1st dimension
+            slice_attention_output(
+                layer_adapter, slicing_scheduler.get_attention_output_dimension(i, match_head_dim=False)
+            )
+
+    if slicing_scheduler.do_slice_head:
+        slice_head(model_adapter, slicing_scheduler.get_head_dimension())
 
 
 @torch.no_grad()

--- a/src/slicegpt/slicing_scheduler.py
+++ b/src/slicegpt/slicing_scheduler.py
@@ -1,0 +1,241 @@
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Callable, final
+
+from slicegpt.model_adapter import SlicingConfig
+
+
+class SlicingScheduler(ABC):
+    """
+    Provides the slicing dimensions for each component of the model.
+
+    Can be data dependent (e.g. computing dimensions based on the results of rotation),
+    use a parametric model (e.g. spline), or can be based on a provided config.
+
+    Saves the slicing dimensions obtained through this scheduler into a running config that can be serialised
+    and later used to re-slice the loaded model.
+    """
+
+    def __init__(self, *, do_slice_head: bool = False):
+        self.slicing_conf: SlicingConfig = SlicingConfig()
+        self.slicing_conf.do_slice_head = do_slice_head
+        self.hidden_size: int = -1
+        self.layers_num: int = -1
+
+    @property
+    def do_slice_head(self) -> bool:
+        """Return whether to slice the head."""
+        return self.slicing_conf.do_slice_head
+
+    def setup(self, *, hidden_size: int, layers_num: int) -> None:
+        """Set up the slicing scheduler with the given model parameters."""
+        self.hidden_size = hidden_size
+        self.layers_num = layers_num
+
+    @final
+    def get_embedding_dimensions(self) -> dict[int, int]:
+        """Return the input embedding dimensions."""
+        val = self._get_input_embedding_dimensions()
+        self.slicing_conf.embedding_dimensions = val
+        return val
+
+    @abstractmethod
+    def _get_input_embedding_dimensions(self) -> dict[int, int]:
+        raise NotImplementedError
+
+    @final
+    def get_attention_input_dimension(self, idx: int) -> int:
+        """Return the attention input dimension for the specified layer index."""
+        val = self._get_attention_input_dimension(idx)
+        self.slicing_conf.attention_input_dimensions[idx] = val
+        return val
+
+    @abstractmethod
+    def _get_attention_input_dimension(self, idx: int) -> int:
+        raise NotImplementedError
+
+    @final
+    def get_attention_output_dimension(self, idx, match_head_dim: bool) -> int:
+        """Return the attention output dimension for the specified layer index."""
+        use_head_dim = match_head_dim and idx == self.layers_num - 1
+        val = self._get_attention_output_dimension(idx) if not use_head_dim else self.get_head_dimension()
+        self.slicing_conf.attention_output_dimensions[idx] = val
+        return val
+
+    @abstractmethod
+    def _get_attention_output_dimension(self, idx: int) -> int:
+        raise NotImplementedError
+
+    @final
+    def get_mlp_input_dimension(self, idx: int) -> int:
+        """Return the mlp input dimension for the specified layer index."""
+        val = self._get_mlp_input_dimension(idx)
+        self.slicing_conf.mlp_input_dimensions[idx] = val
+        return val
+
+    @abstractmethod
+    def _get_mlp_input_dimension(self, idx: int) -> int:
+        raise NotImplementedError
+
+    @final
+    def get_mlp_output_dimension(self, idx: int) -> int:
+        """Return the mlp output dimension for the specified layer index."""
+        use_head_dim = idx == self.layers_num - 1
+        val = self._get_mlp_output_dimension(idx) if not use_head_dim else self.get_head_dimension()
+        self.slicing_conf.mlp_output_dimensions[idx] = val
+        return val
+
+    @abstractmethod
+    def _get_mlp_output_dimension(self, idx: int) -> int:
+        raise NotImplementedError
+
+    @final
+    def get_head_dimension(self) -> int:
+        """Return the LM head dimension."""
+        val = self._get_head_dimension() if self.slicing_conf.do_slice_head else self.hidden_size
+        self.slicing_conf.head_dimension = val
+        return val
+
+    @abstractmethod
+    def _get_head_dimension(self) -> int:
+        raise NotImplementedError
+
+
+class ConfigSlicingScheduler(SlicingScheduler):
+    """Slicing scheduler that returns the dimensions specified in the config."""
+
+    def __init__(self, config: SlicingConfig):
+        super().__init__()
+        self.slicing_conf = config
+
+    def _get_input_embedding_dimensions(self) -> dict[int, int]:
+        return self.slicing_conf.embedding_dimensions
+
+    def _get_attention_input_dimension(self, idx: int) -> int:
+        return self.slicing_conf.attention_input_dimensions[idx]
+
+    def _get_attention_output_dimension(self, idx: int) -> int:
+        return self.slicing_conf.attention_output_dimensions[idx]
+
+    def _get_mlp_input_dimension(self, idx: int) -> int:
+        return self.slicing_conf.mlp_input_dimensions[idx]
+
+    def _get_mlp_output_dimension(self, idx: int) -> int:
+        return self.slicing_conf.mlp_output_dimensions[idx]
+
+    def _get_head_dimension(self) -> int:
+        return self.slicing_conf.head_dimension
+
+
+class ConstSlicingScheduler(SlicingScheduler):
+    """Slicing scheduler that returns the same dimension for all components."""
+
+    def __init__(self, dimension: int, *, do_slice_head: bool = False):
+        super().__init__(do_slice_head=do_slice_head)
+        self.dimension: int = dimension
+
+    def _get_input_embedding_dimensions(self) -> dict[int, int]:
+        return defaultdict(lambda: self.dimension)
+
+    def _get_attention_input_dimension(self, idx: int) -> int:
+        return self.dimension
+
+    def _get_attention_output_dimension(self, idx: int) -> int:
+        return self.dimension
+
+    def _get_mlp_input_dimension(self, idx: int) -> int:
+        return self.dimension
+
+    def _get_mlp_output_dimension(self, idx: int) -> int:
+        return self.dimension
+
+    def _get_head_dimension(self) -> int:
+        return self.dimension
+
+
+class ForwardSlicingScheduler(SlicingScheduler, ABC):
+    """
+    An abstract scheduler that enforces dimension consistency across layers.
+    Applicable only if the slicing is performed in the increasing layer index order.
+    """
+
+    def __init__(self, *, do_slice_head: bool = False):
+        super().__init__(do_slice_head=do_slice_head)
+
+    @final
+    def _get_attention_input_dimension(self, idx: int) -> int:
+        # return the input embedding dimension when at the first attn layer inputs
+        if idx == 0:
+            return self._get_input_embedding_dimensions()[0]  # all dimensions are the same there
+
+        return self._get_mlp_output_dimension(idx - 1)
+
+    @final
+    def _get_mlp_input_dimension(self, idx: int) -> int:
+        return self._get_attention_output_dimension(idx)
+
+
+class FunctionSlicingScheduler(ForwardSlicingScheduler):
+    """
+    A forward slicing scheduler that applies sparsity based on the provided function.
+    """
+
+    def __init__(
+        self,
+        *,
+        mlp_sparsity_func: Callable[[float], float],
+        attn_sparsity_func: Callable[[float], float] = None,
+        round_interval: int = 1,
+        do_slice_head: bool = False,
+    ):
+        super().__init__(do_slice_head=do_slice_head)
+        self.mlp_sparsity: Callable[[float], float] = mlp_sparsity_func
+        self.attn_sparsity: Callable[[float], float] = attn_sparsity_func  # unused for parallel blocks case
+        self.round_interval: int = round_interval
+
+    def _get_layer_dimension(self, idx: int, is_attn_layer: bool = False) -> int:
+        loc = idx / (self.layers_num - 1)
+        assert 0 <= loc <= 1
+        sparsity = self.attn_sparsity(loc) if is_attn_layer else self.mlp_sparsity(loc)
+        assert 0 <= sparsity < 1
+        val = int(self.hidden_size * (1 - sparsity))
+        val -= val % self.round_interval
+        return val
+
+    def _get_input_embedding_dimensions(self) -> dict[int, int]:
+        return defaultdict(lambda: self._get_layer_dimension(0))
+
+    def _get_attention_output_dimension(self, idx: int) -> int:
+        return self._get_layer_dimension(idx, is_attn_layer=True)
+
+    def _get_mlp_output_dimension(self, idx: int) -> int:
+        return self._get_layer_dimension(idx + 1)  # head dimension matching ensures location will not exceed 1
+
+    def _get_head_dimension(self) -> int:
+        return self._get_layer_dimension(self.layers_num - 1)
+
+    @staticmethod
+    def create_linear(
+        mlp_start: float,
+        mlp_end: float,
+        attn_start: float | None = None,
+        attn_end: float | None = None,
+        round_interval: int = 1,
+        do_slice_head: bool = False,
+    ) -> 'FunctionSlicingScheduler':
+        """Create a linear slicing scheduler, mainly as an example for testing."""
+
+        def linear(start: float, end: float) -> Callable[[float], float]:
+            def linear_sparsity_func(location: float) -> float:
+                return start + (end - start) * location
+
+            return linear_sparsity_func
+
+        return FunctionSlicingScheduler(
+            mlp_sparsity_func=linear(mlp_start, mlp_end),
+            attn_sparsity_func=linear(attn_start, attn_end)
+            if (attn_start is not None and attn_end is not None)
+            else None,
+            round_interval=round_interval,
+            do_slice_head=do_slice_head,
+        )

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -6,7 +6,7 @@ from slicegpt.adapters.opt_adapter import OPTModelAdapter
 
 
 def test_layernorm_fusion_replaces_modules() -> None:
-    """Checks that module parameters are changes after applying layernorm fusion"""
+    """Checks that module parameters are changed after applying layernorm fusion"""
     model_name = "facebook/opt-125m"
     model_adapter, _ = hf_utils.get_model_and_tokenizer(model_name)
     assert isinstance(model_adapter, OPTModelAdapter)


### PR DESCRIPTION
Add support for variable sparsity:
- Add `SlicingConfig` that stores slice dimensions used for each layer and component.
- Add an abstract `SlicingScheduler` that determines how to slice each layer.
- Add const/preconfigured slicing scheduler implementations that retain the current functionality.
- Add a new `FunctionSlicingScheduler` that accepts arbitrary sparsity functions and maintains dimensional consistency.