### PR TITLE
Rename Compressible -> Compressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ one needs to implement a new model adapter before using it to slice a new model.
   with each transformer layer of the model, an instance of which is stored at `self.layer`. 
   For example, how to access the attention and MLP components of the transformer layer, and 
   how to update the arguments to the transformer layer's forward method.
-- Implement a compressible transformer layer class that subclasses the transformer layer. 
+- Implement a compressed transformer layer class that subclasses the transformer layer. 
   This class should also  provide an adapted `forward()` method to work with the compressed model. 
   This method should specify how the skip connection orthogonal matrices are used, depending on 
   whether MLP and attention blocks are sequential ([OPT](./src/slicegpt/adapters/opt_adapter.py), 
@@ -79,7 +79,7 @@ Example: [llama_adapter.py](./src/slicegpt/adapters/llama_adapter.py)
 
 ### Using a new model adapter to slice a model
 Once a model adapter is implemented, compressing the model involves three conceptual steps:
-  - Replace modules with compressible equivalents (via `slicegpt.layernorm_fusion.replace_layers`)
+  - Replace modules with compressed equivalents (via `slicegpt.layernorm_fusion.replace_layers`)
   - Fuse layer norms and add rotations to skip connections (via `slicegpt.layernorm_fusion.fuse_modules`)
   - Rotate the inputs and slice the layers (via `slicegpt.rotate.rotate_and_slice`)
 

--- a/src/slicegpt/adapters/llama_adapter.py
+++ b/src/slicegpt/adapters/llama_adapter.py
@@ -15,7 +15,7 @@ from transformers.models.llama.modeling_llama import LlamaConfig, LlamaDecoderLa
 from slicegpt.model_adapter import LayerAdapter, ModelAdapter
 
 
-class CompressibleLlamaDecoderLayer(LlamaDecoderLayer):
+class CompressedLlamaDecoderLayer(LlamaDecoderLayer):
     """
     This class simulates the LlamaDecoderLayer class from transformers
     (https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L376)
@@ -131,7 +131,7 @@ class LlamaModelAdapter(ModelAdapter):
         self._config_type: 'type' = LlamaConfig
         self._layer_adapter_type: 'type' = LlamaLayerAdapter
         self._layer_type: 'type' = LlamaDecoderLayer
-        self._compressible_layer_type: 'type' = CompressibleLlamaDecoderLayer
+        self._compressed_layer_type: 'type' = CompressedLlamaDecoderLayer
         self._layer_norm_type: 'type' = LlamaRMSNorm
 
     @property
@@ -148,7 +148,7 @@ class LlamaModelAdapter(ModelAdapter):
 
     @property
     def no_split_module_classes(self) -> list[str]:
-        return [self._layer_type.__name__, self._compressible_layer_type.__name__]
+        return [self._layer_type.__name__, self._compressed_layer_type.__name__]
 
     @property
     def seqlen(self) -> int:
@@ -181,8 +181,8 @@ class LlamaModelAdapter(ModelAdapter):
     def compute_output_logits(self, input_ids: Tensor) -> FloatTensor:
         return self._model(input_ids=input_ids).logits
 
-    def convert_layer_to_compressible(self, layer: Module, layer_idx: int | None) -> Module:
-        compressed_layer = self._compressible_layer_type(cast(self._config_type, self._config), layer_idx).to(
+    def convert_layer_to_compressed(self, layer: Module, layer_idx: int | None) -> Module:
+        compressed_layer = self._compressed_layer_type(cast(self._config_type, self._config), layer_idx).to(
             self._config.torch_dtype
         )
         compressed_layer.load_state_dict(layer.state_dict(), strict=True)

--- a/src/slicegpt/adapters/opt_adapter.py
+++ b/src/slicegpt/adapters/opt_adapter.py
@@ -15,7 +15,7 @@ from transformers.models.opt.modeling_opt import OPTConfig, OPTDecoderLayer, OPT
 from slicegpt.model_adapter import LayerAdapter, ModelAdapter
 
 
-class CompressibleOPTDecoderLayer(OPTDecoderLayer):
+class CompressedOPTDecoderLayer(OPTDecoderLayer):
     """
     This class simulates the OPTDecoderLayer class from transformers
     but with the addition of a shortcut_Q attributes.
@@ -154,7 +154,7 @@ class OPTModelAdapter(ModelAdapter):
         self._config_type: 'type' = OPTConfig
         self._layer_adapter_type: 'type' = OPTLayerAdapter
         self._layer_type: 'type' = OPTDecoderLayer
-        self._compressible_layer_type: 'type' = CompressibleOPTDecoderLayer
+        self._compressed_layer_type: 'type' = CompressedOPTDecoderLayer
         self._layer_norm_type: 'type' = LayerNorm
 
     @property
@@ -171,7 +171,7 @@ class OPTModelAdapter(ModelAdapter):
 
     @property
     def no_split_module_classes(self) -> list[str]:
-        return [self._layer_type.__name__, self._compressible_layer_type.__name__]
+        return [self._layer_type.__name__, self._compressed_layer_type.__name__]
 
     @property
     def seqlen(self) -> int:
@@ -204,8 +204,8 @@ class OPTModelAdapter(ModelAdapter):
     def compute_output_logits(self, input_ids: Tensor) -> FloatTensor:
         return self._model(input_ids=input_ids).logits
 
-    def convert_layer_to_compressible(self, layer: Module, layer_idx: int | None) -> Module:
-        compressed_layer = self._compressible_layer_type(cast(self._config_type, self._config)).to(
+    def convert_layer_to_compressed(self, layer: Module, layer_idx: int | None) -> Module:
+        compressed_layer = self._compressed_layer_type(cast(self._config_type, self._config)).to(
             self._config.torch_dtype
         )
         compressed_layer.load_state_dict(layer.state_dict(), strict=True)

--- a/src/slicegpt/adapters/phi2_adapter.py
+++ b/src/slicegpt/adapters/phi2_adapter.py
@@ -17,7 +17,7 @@ from transformers.models.phi.modeling_phi import PhiConfig, PhiDecoderLayer, Phi
 from slicegpt.model_adapter import LayerAdapter, ModelAdapter
 
 
-class CompressiblePhiDecoderLayer(PhiDecoderLayer):
+class CompressedPhiDecoderLayer(PhiDecoderLayer):
     """
     This class simulates the PhiDecoderlayer class from PhiModel (PhiForCausalLM)
     https://huggingface.co/microsoft/phi-2/blob/main/modeling_phi.py
@@ -128,7 +128,7 @@ class Phi2ModelAdapter(ModelAdapter):
         self._config_type: 'type' = PhiConfig
         self._layer_adapter_type: 'type' = Phi2LayerAdapter
         self._layer_type: 'type' = PhiDecoderLayer
-        self._compressible_layer_type: 'type' = CompressiblePhiDecoderLayer
+        self._compressed_layer_type: 'type' = CompressedPhiDecoderLayer
         self._layer_norm_type: 'type' = LayerNorm
 
     @property
@@ -145,7 +145,7 @@ class Phi2ModelAdapter(ModelAdapter):
 
     @property
     def no_split_module_classes(self) -> list[str]:
-        return [self._layer_type.__name__, self._compressible_layer_type.__name__]
+        return [self._layer_type.__name__, self._compressed_layer_type.__name__]
 
     @property
     def seqlen(self) -> int:
@@ -178,8 +178,8 @@ class Phi2ModelAdapter(ModelAdapter):
     def compute_output_logits(self, input_ids: Tensor) -> FloatTensor:
         return self._model(input_ids=input_ids).logits
 
-    def convert_layer_to_compressible(self, layer: Module, layer_idx: int | None) -> Module:
-        compressed_layer = self._compressible_layer_type(cast(self._config_type, self._config), layer_idx).to(
+    def convert_layer_to_compressed(self, layer: Module, layer_idx: int | None) -> Module:
+        compressed_layer = self._compressed_layer_type(cast(self._config_type, self._config), layer_idx).to(
             self._config.torch_dtype
         )
         compressed_layer.load_state_dict(layer.state_dict(), strict=True)

--- a/src/slicegpt/layernorm_fusion.py
+++ b/src/slicegpt/layernorm_fusion.py
@@ -12,7 +12,7 @@ from .modules import RMSN
 
 
 def replace_layers(model_adapter: ModelAdapter, verbose: bool = True) -> None:
-    """Replace layers with compressible versions.
+    """Replace layers with compressed versions.
 
     This adds a 'shortcut operation' to each block.
     This function should be called before fusing the modules!
@@ -23,7 +23,7 @@ def replace_layers(model_adapter: ModelAdapter, verbose: bool = True) -> None:
     replace_modules(
         model_adapter.model,
         model_adapter.original_layer_type,
-        model_adapter.convert_layer_to_compressible_and_register_buffers,
+        model_adapter.convert_layer_to_compressed_and_register_buffers,
         replace_layers=True,
     )
 

--- a/src/slicegpt/model_adapter.py
+++ b/src/slicegpt/model_adapter.py
@@ -121,10 +121,10 @@ class ModelAdapter(ABC):
             - self._layer_type: 'type'              = Type of the transformer layer containing forward() method of
                                                       the original model,
                                                       e.g: LlamaDecoderLayer
-            - self._compressible_layer_type: 'type' = Type of the compressible transformer layer defined by the user;
+            - self._compressed_layer_type: 'type'   = Type of the compressed transformer layer defined by the user;
                                                       subclasses the transformer layer class; contains the adapted
                                                       forward() method for the compressed model
-                                                      e.g: CompressibleLlamaDecoderLayer
+                                                      e.g: CompressedLlamaDecoderLayer
             - self._layer_norm_type: 'type'         = Type of the layer norm class used,
                                                       e.g: LlamaRMSNorm
 
@@ -185,7 +185,7 @@ class ModelAdapter(ABC):
     @abstractmethod
     def original_layer_type(self) -> type:
         """
-        The class of the compressible layer (so that we can replace it with a compressed version)
+        The class of the original layer that we plan to replace with a compressed version
         """
         raise NotImplementedError
 
@@ -218,9 +218,9 @@ class ModelAdapter(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def convert_layer_to_compressible(self, layer: Module, layer_idx: int | None) -> Module:
+    def convert_layer_to_compressed(self, layer: Module, layer_idx: int | None) -> Module:
         """
-        Replace the given layer with a compressible version of the layer.
+        Replace the given layer with a compressed version of the layer.
         """
         raise NotImplementedError
 
@@ -267,12 +267,12 @@ class ModelAdapter(ABC):
         raise NotImplementedError
 
     @final
-    def convert_layer_to_compressible_and_register_buffers(self, layer: Module, layer_idx: int | None) -> Module:
+    def convert_layer_to_compressed_and_register_buffers(self, layer: Module, layer_idx: int | None) -> Module:
         """
-        Replace the given layer with a compressible version of the layer. Also register the shortcut_Q matrices
-        to be used in Compressible transformer layer's forward() method to be updated during slicing.
+        Replace the given layer with a compressed version of the layer. Also register the shortcut_Q matrices
+        to be used in Compressed transformer layer's forward() method to be updated during slicing.
         """
-        compressed_layer = self.convert_layer_to_compressible(layer, layer_idx)
+        compressed_layer = self.convert_layer_to_compressed(layer, layer_idx)
         compressed_layer.register_buffer('mlp_shortcut_Q', None)
         compressed_layer.register_buffer('attn_shortcut_Q', None)
         return compressed_layer

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -53,12 +53,12 @@ class ModelAdapterTestBase(ABC):
     def model_adapter(self) -> ModelAdapter:
         return self.create_adapter()
 
-    def test_convert_layer_to_compressible(self, model_adapter: ModelAdapter) -> None:
+    def test_convert_layer_to_compressed(self, model_adapter: ModelAdapter) -> None:
         for i, layer_adapter in enumerate(model_adapter.get_layers()):
-            compressed_layer = model_adapter.convert_layer_to_compressible(layer_adapter.layer, i)
-            assert isinstance(compressed_layer, Module), f"Converted compressible layer {i} is not a torch module"
-            compressed_layer = model_adapter.convert_layer_to_compressible_and_register_buffers(layer_adapter.layer, i)
-            _validate_protocol_attr(compressed_layer, HasShortcuts, f"Converted compressible layer {i} is invalid")
+            compressed_layer = model_adapter.convert_layer_to_compressed(layer_adapter.layer, i)
+            assert isinstance(compressed_layer, Module), f"Converted compressed layer {i} is not a torch module"
+            compressed_layer = model_adapter.convert_layer_to_compressed_and_register_buffers(layer_adapter.layer, i)
+            _validate_protocol_attr(compressed_layer, HasShortcuts, f"Converted compressed layer {i} is invalid")
             # TODO: test actual forward pass dependency on Q
 
     def test_layernorms_have_weight(self, model_adapter: ModelAdapter) -> None:


### PR DESCRIPTION
Renaming `Compressible` to `Compressed`. 

Dmitry's comment in #53 related only to the docstring of one function (`original_layer_type`), so a full rename that I did previously was unnecessary. Reversing it. The most external facing usage is `Compressed<Layer>`, which holds `shortcut_Q`s and provides an adapted `forward()` for the compressed model, so it should definitely be called `Compressed`, as it was originally. 