### PR TITLE
Fix Padding Tokens Initialization for Llama and Phi

### DIFF
--- a/experiments/run_slicegpt_perplexity.py
+++ b/experiments/run_slicegpt_perplexity.py
@@ -228,9 +228,8 @@ def main() -> None:
         f"New embedding dimension: {new_embedding_dimension} (sparsity {100*(1 - new_embedding_dimension / model_adapter.hidden_size):.4f} %)"
     )
 
-    ignore_tokens = [tokenizer.pad_token_id]
     scheduler = ConstSlicingScheduler(new_embedding_dimension)
-    rotate.rotate_and_slice(model_adapter, train_loader, scheduler, ignore_tokens=ignore_tokens)
+    rotate.rotate_and_slice(model_adapter, train_loader, scheduler)
 
     if args.save_dir:
         path = pathlib.Path(args.save_dir)

--- a/src/slicegpt/hf_utils.py
+++ b/src/slicegpt/hf_utils.py
@@ -104,10 +104,8 @@ def get_model_and_tokenizer(
             model = LlamaForCausalLM.from_pretrained(model_path, torch_dtype=dtype, token=token)
             model.config.torch_dtype = dtype
 
-        # TODO: change to <eos>
-        tokenizer.add_special_tokens({"pad_token": "<pad>"})  # Llama-2 models don't have a pad token by default
+        tokenizer.pad_token = tokenizer.eos_token  # Llama-2 models don't have a pad token by default
         model.config.pad_token_id = tokenizer.pad_token_id
-        model.resize_token_embeddings(len(tokenizer), pad_to_multiple_of=8)
         model_adapter = LlamaModelAdapter(model)
     elif "microsoft/phi-2" in model_path:
         if uninitialized:
@@ -118,9 +116,8 @@ def get_model_and_tokenizer(
             model = PhiForCausalLM.from_pretrained(model_path, torch_dtype=dtype, token=token)
             model.config.torch_dtype = dtype
 
-        tokenizer.add_special_tokens({"pad_token": "<pad>"})  # Phi-2 models don't have a pad token by default
+        tokenizer.pad_token = tokenizer.eos_token  # Phi-2 models don't have a pad token by default
         model.config.pad_token_id = tokenizer.pad_token_id
-        model.resize_token_embeddings(len(tokenizer), pad_to_multiple_of=8)
         model_adapter = Phi2ModelAdapter(model)
     else:
         raise NotImplementedError
@@ -139,7 +136,7 @@ def load_sliced_model(
     model_name: str,
     model_path: str,
     *,
-    token: str,
+    token: str | None = None,
     lora_config: LoraConfig = None,
     sparsity: float | None = None,
     round_interval: int | None = 1,


### PR DESCRIPTION
Fixes issue [#60](https://github.com/microsoft/TransformerCompression/issues/60)
Padding tokens are assigned to the end of sequence tokens, thus they don't need to be trained during fine-tuning.
