### PR TITLE
Different logic for test dataloader

### DIFF
--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -67,6 +67,7 @@ def argparser() -> argparse.Namespace:
 
     parser.add_argument('--hf-token', type=str, default=os.getenv('HF_TOKEN', None))
 
+    parser.add_argument('--wandb-project', type=str, default="slicegpt-bench", help="wandb project name.")
     parser.add_argument('--no-wandb', action="store_true", help="Disable wandb.")
     parser.add_argument(
         '--device',
@@ -106,12 +107,12 @@ def main() -> None:
     logging.info(f"Number of available cuda devices: {torch.cuda.device_count()}")
 
     try:
-        wandb.init(project="slicegpt-bench", config=args)
+        wandb.init(project=args.wandb_project, config=args, mode='disabled' if args.no_wandb else None)
     except wandb.UsageError as e:
         # wandb.init will throw an error if the user is not logged in and the process is running in a non-shell
         # environment, e.g. notebook, IDE, no-shell process, etc. In this case, we want to continue without wandb.
-        logging.info(f'Failed to initialize wandb: {e}, continuing without wandb.')
-        wandb.init(project="slicegpt", mode='disabled')
+        logging.info(f'Failed to initialize wandb: {e}, continuing without wandb')
+        wandb.init(project=args.wandb_project, mode='disabled')
 
     if args.load_model_path:
         # load the model from load_model_path to compute perplexity and skip rotation and slicing

--- a/experiments/run_finetuning.py
+++ b/experiments/run_finetuning.py
@@ -112,7 +112,7 @@ def argparser():
     )
     parser.add_argument('--hf-token', type=str, default=os.getenv('HF_TOKEN', None))
 
-    parser.add_argument('--wandb-project', type=str, default="slicegpt-finetuning")
+    parser.add_argument('--wandb-project', type=str, default="slicegpt-finetuning", help="wandb project name.")
     parser.add_argument('--no-wandb', action="store_true", help="Disable wandb.")
     parser.add_argument(
         '--device',

--- a/experiments/run_slicegpt_perplexity.py
+++ b/experiments/run_slicegpt_perplexity.py
@@ -92,6 +92,7 @@ def argparser() -> argparse.Namespace:
 
     parser.add_argument('--hf-token', type=str, default=os.getenv('HF_TOKEN', None))
 
+    parser.add_argument('--wandb-project', type=str, default="slicegpt", help="wandb project name.")
     parser.add_argument('--no-wandb', action="store_true", help="Disable wandb.")
     parser.add_argument(
         '--device',
@@ -131,12 +132,12 @@ def main() -> None:
     logging.info(f"Number of available cuda devices: {torch.cuda.device_count()}")
 
     try:
-        wandb.init(project="slicegpt", config=args, mode='disabled' if args.no_wandb else None)
+        wandb.init(project=args.wandb_project, config=args, mode='disabled' if args.no_wandb else None)
     except wandb.UsageError as e:
         # wandb.init will throw an error if the user is not logged in and the process is running in a non-shell
         # environment, e.g. notebook, IDE, no-shell process, etc. In this case, we want to continue without wandb.
         logging.info(f'Failed to initialize wandb: {e}, continuing without wandb')
-        wandb.init(project="slicegpt", mode='disabled')
+        wandb.init(project=args.wandb_project, mode='disabled')
 
     if args.load_model_path:
         # load the model from load_model_path to compute perplexity and skip rotation and slicing

--- a/experiments/run_slicegpt_perplexity.py
+++ b/experiments/run_slicegpt_perplexity.py
@@ -162,7 +162,7 @@ def main() -> None:
             model.to(config.device)
 
     dataset = data_utils.get_dataset(args.cal_dataset)
-    train_dataset, test_dataset = dataset["train"], dataset["validation"]
+    train_dataset, test_dataset = dataset["train"], dataset["test"]
     train_loader = data_utils.prepare_dataloader(
         dataset=train_dataset,
         tokenizer=tokenizer,
@@ -172,13 +172,10 @@ def main() -> None:
         varied_seqlen=args.varied_seqlen,
         seed=args.seed,
     )
-    test_loader = data_utils.prepare_dataloader(
+    test_loader = data_utils.prepare_test_dataloader(
         dataset=test_dataset,
         tokenizer=tokenizer,
-        max_seqlen=args.ppl_eval_seqlen,
-        batch_size=args.ppl_eval_batch_size,
-        nsamples=args.ppl_eval_nsamples,
-        seed=args.seed,
+        batch_size=args.ppl_eval_batch_size
     )
 
     # evaluate perplexity and exit if sliced model is loaded or if ppl_only is set

--- a/experiments/run_slicegpt_perplexity.py
+++ b/experiments/run_slicegpt_perplexity.py
@@ -173,9 +173,7 @@ def main() -> None:
         seed=args.seed,
     )
     test_loader = data_utils.prepare_test_dataloader(
-        dataset=test_dataset,
-        tokenizer=tokenizer,
-        batch_size=args.ppl_eval_batch_size
+        dataset=test_dataset, tokenizer=tokenizer, batch_size=args.ppl_eval_batch_size
     )
 
     # evaluate perplexity and exit if sliced model is loaded or if ppl_only is set

--- a/experiments/run_zero_shot_tasks.py
+++ b/experiments/run_zero_shot_tasks.py
@@ -69,6 +69,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Use accelerate to put the model on multiple GPUs for evaluation. It is recommended to use it for models with 30B parameters and above.",
     )
+    parser.add_argument('--wandb-project', type=str, default="slicegpt-lm-eval", help="wandb project name.")
     parser.add_argument('--no-wandb', action="store_true", help="Disable wandb.")
     parser.add_argument(
         '--tasks',
@@ -90,12 +91,12 @@ def main() -> None:
     logging.info(f"Number of available cuda devices: {torch.cuda.device_count()}")
 
     try:
-        wandb.init(project="slicegpt-lm-eval", config=args, mode='disabled' if args.no_wandb else None)
+        wandb.init(project=args.wandb_project, config=args, mode='disabled' if args.no_wandb else None)
     except wandb.UsageError as e:
         # wandb.init will throw an error if the user is not logged in and the process is running in a non-shell
         # environment, e.g. notebook, IDE, no-shell process, etc. In this case, we want to continue without wandb.
-        logging.info(f'Failed to initialize wandb: {e}, continuing without wandb.')
-        wandb.init(project="slicegpt-lm-eval", mode='disabled')
+        logging.info(f'Failed to initialize wandb: {e}, continuing without wandb')
+        wandb.init(project=args.wandb_project, mode='disabled')
 
     if args.load_model_path:
         # load the sliced model

--- a/src/slicegpt/data_utils.py
+++ b/src/slicegpt/data_utils.py
@@ -5,7 +5,7 @@ import logging
 
 import datasets
 import torch
-from torch.utils.data import DataLoader, SubsetRandomSampler, Dataset
+from torch.utils.data import DataLoader, Dataset, SubsetRandomSampler
 from transformers import PreTrainedTokenizerBase
 
 
@@ -58,11 +58,10 @@ def get_dataset(name: str) -> datasets.DatasetDict:
     logging.info("Loading dataset done")
     return ds
 
+
 def prepare_test_dataloader(
-    dataset: datasets.Dataset,
-    tokenizer: PreTrainedTokenizerBase,
-    seqlen: int = 2048,
-    batch_size: int = 1) -> DataLoader[dict[str, torch.Tensor]]:
+    dataset: datasets.Dataset, tokenizer: PreTrainedTokenizerBase, seqlen: int = 2048, batch_size: int = 1
+) -> DataLoader[dict[str, torch.Tensor]]:
     """
     Get a DataLoader from a test dataset. This dataloader is used for evaluation on the entirety of the given dataset.
 
@@ -77,16 +76,17 @@ def prepare_test_dataloader(
     """
 
     logging.info(f"Preparing test dataloader")
+
     class TestDataset(Dataset):
         def __init__(self, ds, tokenizer, seqlen=2048):
+            """Tokenize the entire dataset and reshape it into sequences of length seqlen."""
 
             tokenized_ds = tokenizer("\n\n".join(ds['text']), return_tensors='pt')
-
             nsamples = tokenized_ds.input_ids.numel() // seqlen
 
-            input_ids = tokenized_ds.input_ids[0,:nsamples * seqlen]
+            input_ids = tokenized_ds.input_ids[0, : nsamples * seqlen]
             input_ids = input_ids.reshape(nsamples, seqlen)
-            attn_mask = tokenized_ds.attention_mask[0,:nsamples * seqlen]
+            attn_mask = tokenized_ds.attention_mask[0, : nsamples * seqlen]
             attn_mask = attn_mask.reshape(nsamples, seqlen)
 
             self.input_ids = input_ids

--- a/src/slicegpt/data_utils.py
+++ b/src/slicegpt/data_utils.py
@@ -63,10 +63,10 @@ def prepare_test_dataloader(
     dataset: datasets.Dataset, tokenizer: PreTrainedTokenizerBase, seqlen: int = 2048, batch_size: int = 1
 ) -> DataLoader[dict[str, torch.Tensor]]:
     """
-    Get a DataLoader from a test dataset. This dataloader is used for evaluation on the entirety of the given dataset.
+    Get a DataLoader from a test dataset. This dataloader should be used when comparing WikiText2 perplexities with other papers, e.g. SparseGPT (arxiv.org/abs/2301.00774).
 
     Args:
-        dataset: The dataset to create a dataloader from load.
+        dataset: The dataset to create a dataloader from.
         tokenizer: The tokenizer to use.
         seqlen: The sequence length of sequences in the dataset.
         batch_size: The batch size.
@@ -117,7 +117,7 @@ def prepare_dataloader(
     Get a DataLoader from a dataset.
 
     Args:
-        dataset: The dataset to create a dataloader from load.
+        dataset: The dataset to create a dataloader from.
         tokenizer: The tokenizer to use.
         max_seqlen: The maximum sequence length, used for truncation of sequences in the dataset.
         batch_size: The batch size.


### PR DESCRIPTION
The standard wikitext2 perplexity calculation involves tokenizing the entire wikitext2 test split, reshaping into 140 batches of `seqlen` 2048 and evaluating a model on all batches.

In our current dataloader logic we randomly sample the wikitext2 test split, which gives perplexities of 28 +/- 1 instead of 27.65 for OPT-125m. This makes comparing with other papers impossible.

A simple fix is to have different methods for train and test splits - this is what I've now added which gives the correct perplexity. I can't see an obvious way of having a single method which handles both cases, @myshkov @LianaMikael would you have any ideas? Let me know what you think.

To do: update tests, once everyone is happy with the design