### PR TITLE
Fix dataset handling in run_benchmark

### DIFF
--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -129,9 +129,9 @@ def main() -> None:
     else:
         model_adapter.model.to(config.device)
 
-    train_dataset = data_utils.get_dataset(args.eval_dataset)
+    dataset = data_utils.get_dataset(args.eval_dataset)
     train_loader = data_utils.prepare_dataloader(
-        dataset=train_dataset["train"],
+        dataset=dataset["train"],
         tokenizer=tokenizer,
         max_seqlen=model_adapter.seqlen,
         batch_size=args.batch_size,

--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -129,9 +129,9 @@ def main() -> None:
     else:
         model_adapter.model.to(config.device)
 
-    train_dataset, _ = data_utils.get_dataset(args.eval_dataset)
+    train_dataset = data_utils.get_dataset(args.eval_dataset)
     train_loader = data_utils.prepare_dataloader(
-        dataset=train_dataset,
+        dataset=train_dataset["train"],
         tokenizer=tokenizer,
         max_seqlen=model_adapter.seqlen,
         batch_size=args.batch_size,


### PR DESCRIPTION
Hi All,

First of all - thank you for open sourcing SliceGPT. It is a very nice package.

While running various exepriments I bumped into little problem in the tool `run_benchmark.py`.

The invokation:
```
python run_benchmark.py \
           --model facebook/opt-1.3b \
           --sparsity 0.30 \
           --load-model-path out_sliced/*.pt \
           --no-wandb \
           --device cuda:0 
```
gives me:
```
  File "/tmp/run_benchmark.py", line 132, in main                                                              
    train_dataset, _ = data_utils.get_dataset(args.eval_dataset)                                                                                                                                            
ValueError: too many values to unpack (expected 2) 
```
The tiny fix that solves the issue for me is attached in the PR.

Best regards,
Michał