### PR TITLE
Remove duplicate script parameter

### DIFF
--- a/experiments/run_slicegpt_perplexity.py
+++ b/experiments/run_slicegpt_perplexity.py
@@ -97,7 +97,6 @@ def argparser() -> argparse.Namespace:
 
     parser.add_argument('--wandb-project', type=str, default="slicegpt", help="wandb project name.")
     parser.add_argument('--no-wandb', action="store_true", help="Disable wandb.")
-    parser.add_argument('--wandb-project', type=str, default="slicegpt")
     parser.add_argument(
         '--device',
         type=str,

--- a/src/slicegpt/gpu_utils.py
+++ b/src/slicegpt/gpu_utils.py
@@ -7,7 +7,6 @@ import numpy as np
 import torch
 from accelerate import dispatch_model, infer_auto_device_map
 from accelerate.utils import get_balanced_memory
-from torch import Tensor
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -17,7 +16,7 @@ from .model_adapter import ModelAdapter
 
 
 @torch.no_grad()
-def evaluate_ppl(model_adapter: ModelAdapter, testloader: DataLoader[Tensor]) -> float:
+def evaluate_ppl(model_adapter: ModelAdapter, testloader: DataLoader[dict[str, torch.Tensor]]) -> float:
     """
     Evaluate the model's perplexity on the test set using batch processing.
     It is expected that model is already on the correct device.


### PR DESCRIPTION
Fix "ArgumentError: argument --wandb-project: conflicting option string" error when running the perplexity script.