### PR TITLE
Define Q matrices as trainable parameters

### DIFF
--- a/src/slicegpt/model_adapter.py
+++ b/src/slicegpt/model_adapter.py
@@ -289,8 +289,8 @@ class ModelAdapter(ABC):
         """
         compressed_layer = self.convert_layer_to_compressed(layer, layer_idx)
         if not self.parallel_blocks:
-            compressed_layer.register_buffer('mlp_shortcut_Q', None)
-        compressed_layer.register_buffer('attn_shortcut_Q', None)
+            compressed_layer.register_parameter('mlp_shortcut_Q', None)
+        compressed_layer.register_parameter('attn_shortcut_Q', None)
         return compressed_layer
 
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -105,7 +105,7 @@ def test_opt_125m():
         model='facebook/opt-125m',
         sparsity=0.2,
         expected_ppl=34.53,
-        expected_parameters=138_281_664,
+        expected_parameters=147_250_880,
     )
 
 
@@ -119,5 +119,5 @@ def test_phi_2():
         model='microsoft/phi-2',
         sparsity=0.2,
         expected_ppl=11.2691,
-        expected_parameters=2_256_505_856,
+        expected_parameters=2_391_772_160,
     )


### PR DESCRIPTION
This PR changes the definition of Q matrices from buffers to trainable parameters. This should fix the issue #72