### PR TITLE
update embedding dim

### DIFF
--- a/src/slicegpt/rotate.py
+++ b/src/slicegpt/rotate.py
@@ -103,6 +103,7 @@ def slice_embeddings(model_adapter: ModelAdapter, new_embedding_dimensions: dict
     # Slice the embeddings.
     for i, W in enumerate(model_adapter.get_embeddings()):
         W.weight.data = W.weight.data[:, : new_embedding_dimensions[i]]
+        W.embedding_dim = new_embedding_dimensions[i]
 
 
 def rotate_head(model_adapter: ModelAdapter, Q: torch.Tensor) -> None:


### PR DESCRIPTION
When Slice the embeddings, we should also update the embedding dims.
Without this pr: 
```
UninitializedLlamaForCausalLM(
  (model): LlamaModel(
    (embed_tokens): Embedding(32000, 4096, padding_idx=0)
    (layers): ModuleList(
      (0-30): 31 x CompressedLlamaDecoderLayer(
        (self_attn): LlamaSdpaAttention(
          (q_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (k_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (v_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (o_proj): Linear(in_features=4096, out_features=3072, bias=False)
          (rotary_emb): LlamaRotaryEmbedding()
        )
        (mlp): LlamaMLP(
          (gate_proj): Linear(in_features=3072, out_features=11008, bias=False)
          (up_proj): Linear(in_features=3072, out_features=11008, bias=False)
          (down_proj): Linear(in_features=11008, out_features=3072, bias=False)
          (act_fn): SiLU()
        )
        (input_layernorm): RMSN()
        (post_attention_layernorm): RMSN()
      )
      (31): CompressedLlamaDecoderLayer(
        (self_attn): LlamaSdpaAttention(
          (q_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (k_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (v_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (o_proj): Linear(in_features=4096, out_features=3072, bias=False)
          (rotary_emb): LlamaRotaryEmbedding()
        )
        (mlp): LlamaMLP(
          (gate_proj): Linear(in_features=3072, out_features=11008, bias=False)
          (up_proj): Linear(in_features=3072, out_features=11008, bias=False)
          (down_proj): Linear(in_features=11008, out_features=4096, bias=False)
          (act_fn): SiLU()
        )
        (input_layernorm): RMSN()
        (post_attention_layernorm): RMSN()
      )
    )
    (norm): RMSN()
  )
  (lm_head): Linear(in_features=4096, out_features=32000, bias=False)
)
```

With this pr:
```
UninitializedLlamaForCausalLM(
  (model): LlamaModel(
    (embed_tokens): Embedding(32000, 3072, padding_idx=0)
    (layers): ModuleList(
      (0-30): 31 x CompressedLlamaDecoderLayer(
        (self_attn): LlamaSdpaAttention(
          (q_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (k_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (v_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (o_proj): Linear(in_features=4096, out_features=3072, bias=False)
          (rotary_emb): LlamaRotaryEmbedding()
        )
        (mlp): LlamaMLP(
          (gate_proj): Linear(in_features=3072, out_features=11008, bias=False)
          (up_proj): Linear(in_features=3072, out_features=11008, bias=False)
          (down_proj): Linear(in_features=11008, out_features=3072, bias=False)
          (act_fn): SiLU()
        )
        (input_layernorm): RMSN()
        (post_attention_layernorm): RMSN()
      )
      (31): CompressedLlamaDecoderLayer(
        (self_attn): LlamaSdpaAttention(
          (q_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (k_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (v_proj): Linear(in_features=3072, out_features=4096, bias=False)
          (o_proj): Linear(in_features=4096, out_features=3072, bias=False)
          (rotary_emb): LlamaRotaryEmbedding()
        )
        (mlp): LlamaMLP(
          (gate_proj): Linear(in_features=3072, out_features=11008, bias=False)
          (up_proj): Linear(in_features=3072, out_features=11008, bias=False)
          (down_proj): Linear(in_features=11008, out_features=4096, bias=False)
          (act_fn): SiLU()
        )
        (input_layernorm): RMSN()
        (post_attention_layernorm): RMSN()
      )
    )
    (norm): RMSN()
  )
  (lm_head): Linear(in_features=4096, out_features=32000, bias=False)
)
```
@pashminacameron @nailimixaM