### PR TITLE
Update bo_finetuning.py to match argname

### DIFF
--- a/experiments/bo_finetuning.py
+++ b/experiments/bo_finetuning.py
@@ -16,7 +16,7 @@ config_space = {
     "weight-decay": loguniform(1e-5, 1e-1),
     "adam-beta1": uniform(0.9, 0.99),
     "adam-beta2": uniform(0.9, 0.999),
-    "adam-eps": loguniform(1e-9, 1e-6),
+    "adam-epsilon": loguniform(1e-9, 1e-6),
     "num-warmup-steps": randint(0, 10000),
     "lr-scheduler-type": choice(["linear", "cosine", "linear_with_warmup", "cosine_with_warmup"]),
     "lora-alpha": loguniform(4, 256),


### PR DESCRIPTION
Python argparser automagically transfers the value to the correct (i.e. closest matching) argname anyway, but we should have this corrected nevertheless.