### PR TITLE
Refactor QuaRot [WIP]

### DIFF
--- a/src/quarot/modeling_llama.py
+++ b/src/quarot/modeling_llama.py
@@ -1,0 +1,209 @@
+from typing import Optional, Tuple
+
+import torch
+from transformers import Cache, LlamaConfig
+from transformers.models.llama.modeling_llama import (
+    LlamaFlashAttention2,
+    LlamaForCausalLM,
+    LlamaMLP,
+    apply_rotary_pos_emb,
+)
+from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
+
+from quarot.nn import FP16ActQuantizer, OnlineHadamard, QuarotFP16Linear
+from slicegpt.modules import RMSN
+
+ALL_LAYERNORM_LAYERS.append(RMSN)
+
+
+class QuarotLlamaConfig(LlamaConfig):
+    model_type = "llama_quarot"
+
+
+class QuarotFP16LlamaAttention(LlamaFlashAttention2):
+    def __init__(self, a_bits: int = 16, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.quantizer = FP16ActQuantizer(a_bits)
+        self.q_proj = QuarotFP16Linear.from_float(self.q_proj)
+        self.k_proj = QuarotFP16Linear.from_float(self.k_proj)
+        self.v_proj = QuarotFP16Linear.from_float(self.v_proj)
+        self.o_proj_hadamard = OnlineHadamard(self.num_heads)
+        self.o_proj = torch.nn.Sequential(FP16ActQuantizer(a_bits), QuarotFP16Linear.from_float(self.o_proj))
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Cache] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        output_attentions = False
+
+        bsz, q_len, _ = hidden_states.size()
+
+        hidden_states = self.quantizer(hidden_states)
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        # Flash attention requires the input to have the shape
+        # batch_size x seq_length x head_dim x hidden_dim
+        # therefore we just need to keep the original shape
+        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim)
+        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim)
+        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim)
+
+        kv_seq_len = key_states.shape[1]
+        kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
+        cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin, position_ids, unsqueeze_dim=2
+        )
+
+        past_key_value = getattr(self, "past_key_value", past_key_value)
+        assert past_key_value is not None
+        # sin and cos are specific to RoPE models; position_ids needed for the static cache
+
+        cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position, "attention_mask": attention_mask}
+        cache_out = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
+
+        dropout_rate = self.attention_dropout if self.training else 0.0
+
+        assert self.is_causal
+
+        if isinstance(cache_out, tuple):
+            key_states, value_states = cache_out
+            attn_output = self._flash_attention_forward(
+                query_states, key_states, value_states, query_length=q_len, attention_mask=attention_mask
+            )
+        else:
+            attn_output = cache_out(query_states)
+
+        attn_output = self.o_proj_hadamard(attn_output.transpose(-1, -2)).transpose(-1, -2)
+        attn_output = attn_output.reshape(bsz, q_len, self.hidden_size).contiguous()
+        attn_output = self.o_proj(attn_output)
+
+        if not output_attentions:
+            attn_weights = None
+
+        return attn_output, attn_weights, past_key_value
+
+
+# class QuarotLlamaAttention(QuarotFP16LlamaAttention):
+
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.quantizer = quarot.nn.Quantizer()
+#         self.q_proj = quarot.nn.Linear4bit.from_float(self.q_proj)
+#         self.k_proj = quarot.nn.Linear4bit.from_float(self.k_proj)
+#         self.v_proj = quarot.nn.Linear4bit.from_float(self.v_proj)
+#         self.o_proj_hadamard = quarot.nn.OnlineHadamard(self.num_heads)
+#         self.o_proj = torch.nn.Sequential(
+#             quarot.nn.Quantizer(),
+#             quarot.nn.Linear4bit.from_float(self.o_proj)
+#         )
+
+
+class QuarotFP16LlamaMLP(LlamaMLP):
+    def __init__(self, a_bits: int = 16, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.quantizer = FP16ActQuantizer(a_bits)
+        self.up_proj = QuarotFP16Linear.from_float(self.up_proj)
+        self.gate_proj = QuarotFP16Linear.from_float(self.gate_proj)
+        self.down_proj = torch.nn.Sequential(
+            OnlineHadamard(self.intermediate_size),
+            FP16ActQuantizer(a_bits),
+            QuarotFP16Linear.from_float(self.down_proj),
+        )
+
+    def forward(self, x):
+        x = self.quantizer(x)
+        return super().forward(x)
+
+
+# class QuarotLlamaMLP(LlamaMLP):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.quantizer = quarot.nn.Quantizer()
+#         self.up_proj = quarot.nn.Linear4bit.from_float(self.up_proj)
+#         self.gate_proj = quarot.nn.Linear4bit.from_float(self.gate_proj)
+#         self.down_proj = torch.nn.Sequential(
+#             quarot.nn.OnlineHadamard(self.intermediate_size),
+#             quarot.nn.Quantizer(),
+#             quarot.nn.Linear4bit.from_float(self.down_proj)
+#         )
+
+#     def forward(self, x):
+#         x = self.quantizer(x)
+#         return super().forward(x)
+
+
+class QuarotFP16LlamaForCausalLM(LlamaForCausalLM):
+    def __init__(self, a_bits: int = 16, config=None):
+        super().__init__(config)
+        assert config._attn_implementation == "flash_attention_2"
+        self.model.norm = RMSN(config.hidden_size, eps=config.rms_norm_eps)
+        for layer_idx, layer in enumerate(self.model.layers):
+            layer.self_attn = QuarotFP16LlamaAttention(a_bits, config=config, layer_idx=layer_idx)
+            layer.input_layernorm = RMSN(config.hidden_size, eps=config.rms_norm_eps)
+            layer.post_attention_layernorm = RMSN(config.hidden_size, eps=config.rms_norm_eps)
+            layer.mlp = QuarotFP16LlamaMLP(a_bits, config=config)
+
+
+# class QuarotLlamaForCausalLM(LlamaForCausalLM):
+# def __init__(self, config):
+#     super().__init__(config)
+#     assert config._attn_implementation == "flash_attention_2"
+#     self.norm = quarot.nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+#     for layer_idx, layer in enumerate(self.model.layers):
+#         layer.self_attn = QuarotLlamaAttention(config=config, layer_idx=layer_idx)
+#         layer.input_layernorm = quarot.nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+#         layer.post_attention_layernorm = quarot.nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+#         layer.mlp = QuarotLlamaMLP(config=config)
+#     self.cache_dtype = "int4"
+#     self._expected_max_length = None
+
+
+# def build_cache(self, batch_size, page_size, max_length):
+#     device = self.model.layers[0].self_attn.v_proj.weight.device
+#     dtype = self.cache_dtype or self.model.layers[0].self_attn.v_proj.weight.dtype
+
+#     num_heads = self.config.num_key_value_heads
+#     model_dim = self.config.hidden_size
+#     head_dim = model_dim // num_heads
+#     disable_quant = self.cache_dtype == "float16"
+#     return quarot.transformers.MultiLayerPagedKVCache4Bit(
+#         batch_size=batch_size,
+#         page_size=page_size,
+#         max_seq_len=max_length,
+#         device=device,
+#         n_layers=len(self.model.layers),
+#         num_heads=num_heads,
+#         head_dim=head_dim,
+#         disable_quant=disable_quant,
+#         hadamard_dtype=None if disable_quant else torch.float16
+#     )
+
+# def _get_logits_processor(self, generation_config, *args, **kwargs):
+#     # This is a hack to get the max length from generation_config.
+#     # Doing it here because max_length might not be set before this
+#     # method is called.
+#     self._expected_max_length = generation_config.max_length # This value will be reset at the next forward call
+#     return super()._get_logits_processor(generation_config, *args, **kwargs)
+
+
+# def forward(self, input_ids, *args, past_key_values=None, **kwargs):
+#     if past_key_values is None:
+#         max_length = self._expected_max_length or input_ids.shape[1]
+#         self._expected_max_length = None # Reset this value.
+#         past_key_values = self.build_cache(
+#             input_ids.shape[0],
+#             page_size=max_length,  # For now working with single page per batch.
+#             max_length=max_length)
+#     out = super().forward(input_ids, *args, past_key_values=past_key_values, **kwargs)
+#     return out

--- a/src/quarot/nn/__init__.py
+++ b/src/quarot/nn/__init__.py
@@ -1,0 +1,3 @@
+from .hadamard import OnlineHadamard
+from .linear import QuarotFP16Linear
+from .quantizer import FP16ActQuantizer

--- a/src/quarot/nn/hadamard.py
+++ b/src/quarot/nn/hadamard.py
@@ -1,0 +1,28 @@
+import torch
+
+from quarot.hadamard_utils import get_hadK, matmul_hadU_cuda
+
+
+class OnlineHadamard(torch.nn.Module):
+    def __init__(self, hadamard_dim, force_fp32=False):
+        super().__init__()
+        self.fp32_had = force_fp32
+        had_rem_dim, self.rem_dim = get_hadK(hadamard_dim)
+        if had_rem_dim is not None:
+            self.register_buffer("had_rem_dim", had_rem_dim)
+            if not self.fp32_had:
+                self.had_rem_dim = self.had_rem_dim.to(torch.float16)
+        else:
+            self.had_rem_dim = None
+
+    def forward(self, x):
+        x_dtype = x.dtype
+        if self.fp32_had:
+            x = x.float()
+
+        x = matmul_hadU_cuda(
+            x, self.had_rem_dim, self.rem_dim
+        )  # NB this uses a CUDA kernel from fast_hadamard_transform
+
+        x = x.to(x_dtype)
+        return x

--- a/src/quarot/nn/linear.py
+++ b/src/quarot/nn/linear.py
@@ -1,0 +1,93 @@
+import torch
+
+from quarot.quant_utils import PackedQuantizedTensor
+
+
+class QuarotFP16Linear(torch.nn.Module):
+    def __init__(self, in_features, out_features, bias=False, dtype=torch.float16):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.register_buffer('weight_scales', torch.zeros((self.out_features, 1), requires_grad=False))
+        self.register_buffer('weight', torch.zeros((self.out_features, self.in_features), dtype=dtype))
+        if bias:
+            self.register_buffer('bias', torch.zeros((self.out_features), dtype=dtype))
+        else:
+            self.bias = None
+
+    def forward(self, x):
+        assert isinstance(x, PackedQuantizedTensor)  # Quantized input is given
+        x, scales_x = x.quantized_x, x.scales_x
+
+        # perform matmul with the emulated quantized tensors
+        x = x @ self.weight.T
+
+        # symmetric dequantization
+        x = (x * scales_x) * self.weight_scales.T
+
+        if self.bias is not None:
+            x = x + self.bias
+
+        return x
+
+    @staticmethod
+    def from_float(
+        module: torch.nn.Linear,
+        weight_scales=None,
+    ) -> 'QuarotFP16Linear':
+        '''
+        Generate a new QuarotFP16Linear module from a FP16 Linear module.
+        The weight matrix should have the same shape as the weight matrix of the FP16 Linear module and rounded using torch.round()
+        routine. We will convert it and save it in the int_weight buffer.
+        '''
+        weight_matrix = module.weight.data
+        quarot_fp16_module = QuarotFP16Linear(
+            module.in_features, module.out_features, bias=module.bias is not None, dtype=weight_matrix.dtype
+        ).to(weight_matrix.dtype)
+
+        if weight_scales is not None:
+            assert weight_scales.shape == (module.out_features, 1), 'weight_scales should have shape (out_features, 1)'
+            weight_matrix = weight_matrix.cuda()
+            quarot_fp16_module.weight_scales.copy_(weight_scales.to(weight_matrix.dtype))
+            int_rounded_weight = (weight_matrix / weight_scales.cuda()).round()
+            quarot_fp16_module.weight.copy_(int_rounded_weight.cpu())
+
+            if module.bias is not None:
+                quarot_fp16_module.bias.copy_(module.bias)
+
+        return quarot_fp16_module
+
+
+# class Linear4bit(torch.nn.Module):
+#     def __init__(self, in_features, out_features, bias=False, dtype=torch.float16):
+#         '''
+#         Symmetric 4-bit Linear Layer.
+#         '''
+#         super().__init__()
+#         self.in_features = in_features
+#         self.out_features = out_features
+#         self.register_buffer('weight_scales',
+#                              torch.zeros((self.out_features, 1), requires_grad=False))
+#         self.register_buffer('weight', (torch.randint(1, 7, (self.out_features, self.in_features // 2),
+#                                                              # SubByte weight
+#                                                              dtype=torch.uint8, requires_grad=False)))
+#         if bias:
+#             self.register_buffer('bias', torch.zeros((self.out_features), dtype=dtype))
+#         else:
+#             self.bias = None
+
+#     def forward(self, x):
+#         #if torch.cuda.current_device() != x.device:
+#         #    torch.cuda.set_device(x.device)
+
+#         assert type(x) == quarot.PackedQuantizedTensor #Quantized input is given
+#         x, scales_x = x.quantized_x, x.scales_x
+#         #shape_handler = ShapeHandler(quantized_x)
+#         #quantized_x = shape_handler.flatten(quantized_x)
+#         x = quarot.matmul(x, self.weight)
+#         #out = shape_handler.unflatten(
+#         #    quarot.sym_dequant(in_result, scales_x, self.weight_scales))
+#         if self.bias is not None:
+#             return quarot.sym_dequant(x, scales_x, self.weight_scales) + self.bias
+#         else:
+#             return quarot.sym_dequant(x, scales_x, self.weight_scales)

--- a/src/quarot/nn/quantizer.py
+++ b/src/quarot/nn/quantizer.py
@@ -1,0 +1,31 @@
+import torch
+
+from quarot.quant_utils import PackedQuantizedTensor, get_minq_maxq
+
+# class Quantizer(torch.nn.Module):
+#     def __init__(self, input_clip_ratio=1.0):
+#         super().__init__()
+#         self.input_clip_ratio = input_clip_ratio
+
+#     def forward(self, x):
+#         scales_x = (torch.max(torch.abs(x), dim=-1)[0].unsqueeze(1)/7).to(torch.float16) * self.input_clip_ratio
+#         quantized_x = quarot.sym_quant(x, scales_x)
+#         packed_tensor = quarot.PackedQuantizedTensor(quantized_x, scales_x)
+#         return packed_tensor
+
+
+class FP16ActQuantizer(torch.nn.Module):
+    # TODO: sort out device management here
+    def __init__(self, a_bits: int = 16, input_clip_ratio=1.0):
+        super().__init__()
+        self.min_q, self.max_q = get_minq_maxq(a_bits, True)
+        self.input_clip_ratio = input_clip_ratio
+
+    def forward(self, x: torch.Tensor) -> PackedQuantizedTensor:
+        scales_x = (torch.max(torch.abs(x), dim=-1)[0].unsqueeze(-1) / self.max_q.to(x.device)).to(
+            torch.float16
+        ) * self.input_clip_ratio
+
+        quantized_x = torch.round(x / scales_x)
+        quantized_x = torch.clip(quantized_x, self.min_q.to(x.device), self.max_q.to(x.device))
+        return PackedQuantizedTensor(quantized_x, scales_x)

--- a/src/quarot/quant_utils.py
+++ b/src/quarot/quant_utils.py
@@ -1,15 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import logging
-import math
-
-import fast_hadamard_transform
 import torch
-
-from slicegpt import utils
-
-from .hadamard_utils import matmul_hadU_cuda
 
 
 def get_minq_maxq(bits, sym):
@@ -52,189 +44,6 @@ def sym_quant_dequant(x, scale, maxq):
     return sym_dequant(*sym_quant(x, scale, maxq))
 
 
-class ActQuantizer(torch.nn.Module):
-
-    '''
-    A class for quantizing the activations. We only support (both sym. and asym.) per-token quantization
-    for the activations.
-    '''
-
-    def __init__(self):
-        super(ActQuantizer, self).__init__()
-        self.register_buffer('maxq', torch.tensor(0))
-        self.register_buffer('scale', torch.zeros(1))
-        self.register_buffer('zero', torch.zeros(1))
-        self.bits = 16
-
-    def free(self):
-        self.zero = None
-        self.scale = None
-
-    def forward(self, x):
-        x_dtype = x.dtype
-        if self.bits == 16:
-            return x
-        elif self.sym:
-            return sym_quant_dequant(x, self.scale, self.maxq).to(x_dtype)
-        return asym_quant_dequant(x, self.scale, self.zero, self.maxq).to(x_dtype)
-
-    # Different from `forward`, this method returns quantized integers, scales (and zeros if asymmetric).
-    def quantize(self, x):
-        if self.sym:
-            return sym_quant(x, self.scale, self.maxq)
-        else:
-            return asym_quant(x, self.scale, self.zero, self.maxq)
-
-    def configure(self, bits, groupsize=-1, sym=False, clip_ratio=1.0):
-        _, self.maxq = get_minq_maxq(bits, sym)
-        self.bits = bits
-        self.groupsize = groupsize
-        self.sym = sym
-        self.clip_ratio = clip_ratio
-        assert self.clip_ratio <= 1 and self.clip_ratio > 0, 'Clip ratio should be in (0, 1]'
-
-    def find_params_per_token_groupwise(self, x):
-        init_shape = x.shape
-        reshaped_x = x.reshape(-1, x.shape[-2], x.shape[-1] // self.groupsize, self.groupsize)
-
-        xmax = torch.amax(reshaped_x, dim=3, keepdim=True) * self.clip_ratio
-        xmin = torch.amin(reshaped_x, dim=3, keepdim=True) * self.clip_ratio
-        if self.sym:
-            xmax = torch.maximum(torch.abs(xmin), xmax)
-            tmp = xmax == 0
-            self.scale = xmax / self.maxq
-            self.scale[tmp] = 1
-            self.zero = torch.zeros_like(self.scale)
-        else:
-            tmp = (xmin == 0) & (xmax == 0)
-            xmin[tmp] = -1
-            xmax[tmp] = +1
-            self.scale = (xmax - xmin) / self.maxq
-            self.zero = torch.round(-xmin / self.scale)
-
-        self.scale = self.scale.repeat(1, 1, 1, self.groupsize).reshape(init_shape)
-        self.zero = self.zero.repeat(1, 1, 1, self.groupsize).reshape(init_shape)
-
-    def find_params(self, x):
-        if self.bits == 16:
-            return
-
-        dev = x.device
-        self.maxq = self.maxq.to(dev)
-
-        init_shape = x.shape
-
-        if self.groupsize > 0:
-            # group-wise per-token quantization
-            self.find_params_per_token_groupwise(x)
-            utils.cleanup_memory()
-            return
-
-        reshaped_x = x.reshape((-1, x.shape[-1]))
-
-        tmp = torch.zeros(reshaped_x.shape[0], device=dev)
-        xmin = torch.minimum(reshaped_x.min(1)[0], tmp) * self.clip_ratio
-        xmax = torch.maximum(reshaped_x.max(1)[0], tmp) * self.clip_ratio
-        if self.sym:
-            xmax = torch.maximum(torch.abs(xmin), xmax)
-            tmp = xmax == 0
-            self.scale = (xmax / self.maxq).unsqueeze(1).repeat(1, reshaped_x.shape[-1])
-            self.scale[tmp] = 1
-            self.scale = self.scale.reshape(init_shape)
-            self.zero = torch.zeros_like(self.scale)
-        else:
-            tmp = (xmin == 0) & (xmax == 0)
-            xmin[tmp] = -1
-            xmax[tmp] = +1
-            self.scale = (xmax - xmin) / self.maxq
-            self.zero = torch.round(-xmin / self.scale)
-
-            self.scale = self.scale.unsqueeze(1).repeat(1, reshaped_x.shape[-1]).reshape(init_shape)
-            self.zero = self.zero.unsqueeze(1).repeat(1, reshaped_x.shape[-1]).reshape(init_shape)
-
-
-class ActQuantWrapper(torch.nn.Module):
-    '''
-    Wrapper for torch.nn.Linear blocks to emulate activation quantization. It emulates the quantization
-    of the input and output activations of the linear layer. In addition, it can apply an online Hadamard
-    transform (partial or full) to the input activations.
-    '''
-
-    def __init__(self, module: torch.nn.Linear):
-        super(ActQuantWrapper, self).__init__()
-        assert isinstance(module, torch.nn.Linear)
-        self.module = module
-        self.weight = module.weight
-        self.bias = module.bias
-        self.input_quantizer = ActQuantizer()
-        self.output_quantizer = ActQuantizer()
-        self.register_buffer('had_K', torch.tensor(0))
-        self._buffers['had_K'] = None
-        self.K = 1
-        self.online_full_had = False
-        self.online_partial_had = False
-        self.had_dim = 0
-        self.fp32_had = False
-
-    def extra_repr(self) -> str:
-        str_ = f'Input Quantizer Bits: {self.input_quantizer.bits}'
-        if self.input_quantizer.bits < 16:
-            str_ += f' (Asymmetric Per-Token)' if not self.input_quantizer.sym else f' (Symmetric Per-Token)'
-
-        str_ += f'\nOutput Quantizer Bits: {self.output_quantizer.bits}'
-        if self.output_quantizer.bits < 16:
-            str_ += f' (Asymmetric Per-Token)' if not self.output_quantizer.sym else f' (Symmetric Per-Token)'
-
-        return str_
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x_dtype = x.dtype
-
-        # Rotate, if needed
-        if self.online_full_had:
-
-            if self.fp32_had:  # Full Hadamard in FP32
-                x = matmul_hadU_cuda(x.float(), self.had_K, self.K).to(x_dtype)
-            else:  # Full Hadamard in FP16
-                x = matmul_hadU_cuda(x, self.had_K, self.K)
-
-        elif self.online_partial_had:
-            # todo: implement this in QAttention to avoid reshaping!
-
-            if self.fp32_had:
-                x = x.float()
-
-            init_shape = x.shape
-            if self.K == 1:
-                x = fast_hadamard_transform.hadamard_transform(
-                    x.reshape(-1, init_shape[-1] // self.had_dim, self.had_dim).transpose(1, 2),
-                    scale=1 / math.sqrt(init_shape[-1] // self.had_dim),
-                ).transpose(1, 2)
-            else:
-                x = (self.had_K.to(x.dtype) @ x.reshape(-1, init_shape[-1] // self.had_dim, self.had_dim)) / math.sqrt(
-                    init_shape[-1] // self.had_dim
-                )
-
-            if self.fp32_had:
-                x = x.to(x_dtype)
-            x = x.reshape(init_shape)
-
-        if self.input_quantizer.bits < 16:  # Quantize, if needed
-            self.input_quantizer.find_params(x)
-            x = self.input_quantizer(x).to(x_dtype)
-            self.input_quantizer.free()
-
-        # Forward pass through the linear layer
-        x = self.module(x).to(x_dtype)
-
-        if self.output_quantizer.bits < 16:  # Quantize the output, if needed
-            self.output_quantizer.find_params(x)
-            x = self.output_quantizer(x).to(x_dtype)
-            self.output_quantizer.free()
-
-        return x
-
-
 class WeightQuantizer(torch.nn.Module):
     '''From GPTQ Repo'''
 
@@ -270,8 +79,8 @@ class WeightQuantizer(torch.nn.Module):
         '''
         Calculates the quantization parameters max_quantized_value, scale and zero from the weight tensor w.
         '''
-        if self.bits == 16:
-            return
+        # if self.bits == 16:
+        #     return
 
         dev = w.device
         self.max_quantized_value = self.max_quantized_value.to(dev)
@@ -349,55 +158,31 @@ class WeightQuantizer(torch.nn.Module):
         return torch.all(self.scale != 0)
 
 
-def wrap_linears_with_actquantwrapper(module: torch.nn.Module, name: str = '') -> None:
+def get_linear_modules(module: torch.nn.Module, name: str = '') -> dict[str, torch.nn.Linear]:
     """
-    Wraps the linear blocks in the model with ActQuantWrapper.
-    """
-    if isinstance(module, ActQuantWrapper):
-        return
-
-    linear_type = torch.nn.Linear
-
-    for attribute in dir(module):
-        module_attribute = getattr(module, attribute)
-        if isinstance(module_attribute, linear_type):
-            setattr(module, attribute, ActQuantWrapper(module_attribute))
-        elif isinstance(module_attribute, (torch.nn.Sequential, torch.nn.ModuleList)):
-            replaced = [
-                ActQuantWrapper(child) if isinstance(child, linear_type) else child
-                for child in module_attribute.children()
-            ]
-            setattr(module, attribute, type(module_attribute)(replaced))
-
-    for child_name, child in module.named_children():
-        wrap_linears_with_actquantwrapper(child, f'{name}.{child_name}' if name else child_name)
-
-
-def get_quantizeable_modules(module: torch.nn.Module, name: str = '') -> dict[str, ActQuantWrapper]:
-    """
-    Get all the ActQuantWrapper modules in the model as a dictionary of name: module pairs.
+    Get all the torch.nn.Linear modules in the model as a dictionary of name: module pairs.
     """
     res = {}
-    if isinstance(module, ActQuantWrapper):
+    if isinstance(module, torch.nn.Linear):
         res[name] = module
     else:
         for child_name, child in module.named_children():
-            res.update(get_quantizeable_modules(child, name=f'{name}.{child_name}' if name else child_name))
+            res.update(get_linear_modules(child, name=f'{name}.{child_name}' if name else child_name))
     return res
 
 
-def llama_down_proj_groupsize(model, groupsize):
+class PackedQuantizedTensor:
+    def __init__(self, quantized_x: torch.Tensor, scales_x: torch.Tensor):
+        self.quantized_x = quantized_x
+        self.scales_x = scales_x
 
-    assert groupsize > 1, 'groupsize should be greater than 1!'
+    def size(self):
+        return self.quantized_x.size()
 
-    if model.config.intermediate_size % groupsize == 0:
-        logging.info(f'(Act.) Groupsiz = Down_proj Groupsize: {groupsize}')
-        return groupsize
+    @property
+    def device(self):
+        return self.quantized_x.device
 
-    group_num = int(model.config.hidden_size / groupsize)
-    assert groupsize * group_num == model.config.hidden_size, 'Invalid groupsize for llama!'
-
-    down_proj_groupsize = model.config.intermediate_size // group_num
-    assert down_proj_groupsize * group_num == model.config.intermediate_size, 'Invalid groupsize for down_proj!'
-    logging.info(f'(Act.) Groupsize: {groupsize}, Down_proj Groupsize: {down_proj_groupsize}')
-    return down_proj_groupsize
+    @property
+    def dtype(self):
+        return self.quantized_x.dtype

--- a/src/quarot/rotation_utils.py
+++ b/src/quarot/rotation_utils.py
@@ -1,12 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import functools
-import math
-
 import torch
 import tqdm
-from fast_hadamard_transform import hadamard_transform
 
 from slicegpt import utils
 from slicegpt.rotate import (
@@ -19,10 +15,8 @@ from slicegpt.rotate import (
     rotate_mlp_output,
 )
 
-from .hadamard_utils import apply_exact_had_to_linear, get_hadK, is_pow2, random_hadamard_matrix
+from .hadamard_utils import apply_exact_had_to_linear, random_hadamard_matrix
 from .model_adapter import ModelAdapter
-from .monkeypatch import add_wrapper_after_function_call_in_method
-from .quant_utils import ActQuantizer, get_quantizeable_modules
 
 
 @torch.inference_mode()
@@ -53,85 +47,3 @@ def rotate_model(model_adapter: ModelAdapter, seed: int = 0) -> None:
         apply_exact_had_to_linear(layer_adapter.get_attention_output(), had_dim=-1, output=False)
 
     utils.cleanup_memory()
-
-
-class QKRotationWrapper(torch.nn.Module):
-    def __init__(self, func, config, *args, **kwargs):
-        super().__init__()
-        self.config = config
-        num_heads = config.num_attention_heads
-        model_dim = config.hidden_size
-        head_dim = model_dim // num_heads
-        assert is_pow2(head_dim), f'Only power of 2 head_dim is supported for K-cache Quantization!'
-        self.func = func
-        self.k_quantizer = ActQuantizer()
-        self.k_bits = 16
-        if kwargs is not None:
-            assert kwargs['k_groupsize'] in [
-                -1,
-                head_dim,
-            ], f'Only token-wise/{head_dim}g quantization is supported for K-cache'
-            self.k_bits = kwargs['k_bits']
-            self.k_groupsize = kwargs['k_groupsize']
-            self.k_sym = kwargs['k_sym']
-            self.k_clip_ratio = kwargs['k_clip_ratio']
-            self.k_quantizer.configure(
-                bits=self.k_bits,
-                groupsize=-1,  # we put -1 to be toke-wise quantization and handle head-wise quantization by ourself
-                sym=self.k_sym,
-                clip_ratio=self.k_clip_ratio,
-            )
-
-    def forward(self, *args, **kwargs):
-        q, k = self.func(*args, **kwargs)
-        dtype = q.dtype
-        q = hadamard_transform(q.float(), scale=1 / math.sqrt(q.shape[-1])).to(dtype)
-        k = hadamard_transform(k.float(), scale=1 / math.sqrt(k.shape[-1])).to(dtype)
-        (bsz, num_heads, seq_len, head_dim) = k.shape
-
-        if self.k_groupsize == -1:  # token-wise quantization
-            token_wise_k = k.transpose(1, 2).reshape(-1, self.config.hidden_size)
-            self.k_quantizer.find_params(token_wise_k)
-            k = self.k_quantizer(token_wise_k).reshape((bsz, seq_len, num_heads, head_dim)).transpose(1, 2).to(q)
-        else:  # head-wise quantization
-            per_head_k = k.view(-1, head_dim)
-            self.k_quantizer.find_params(per_head_k)
-            k = self.k_quantizer(per_head_k).reshape((bsz, num_heads, seq_len, head_dim)).to(q)
-
-        self.k_quantizer.free()
-
-        return q, k
-
-
-def add_qk_rotation_wrapper_after_function_call_in_forward(module, function_name, *args, **kwargs):
-    '''
-    This function adds a rotation wrapper after the output of a function call in forward.
-    Only calls directly in the forward function are affected. calls by other functions called in forward are not affected.
-    '''
-    attr_name = f"{function_name}_qk_rotation_wrapper"
-    assert not hasattr(module, attr_name)
-    wrapper = add_wrapper_after_function_call_in_method(
-        module, "forward", function_name, functools.partial(QKRotationWrapper, *args, **kwargs)
-    )
-    setattr(module, attr_name, wrapper)
-
-
-def add_online_hadamards(model, fp32_had: bool = False) -> None:
-    '''
-    Set the online Hadamard matrices for the MLP down-projection and attention out-projection.
-    '''
-    quantizeable_modules = get_quantizeable_modules(model)
-    for name, module in quantizeable_modules.items():
-        if 'down_proj' in name:
-            had_K, K = get_hadK(model.config.intermediate_size)
-            module.online_full_had = True
-            module.had_K = had_K
-            module.K = K
-            module.fp32_had = fp32_had
-        elif 'o_proj' in name:
-            had_K, K = get_hadK(model.config.num_attention_heads)
-            module.online_partial_had = True
-            module.had_K = had_K
-            module.K = K
-            module.had_dim = model.config.hidden_size // model.config.num_attention_heads
-            module.fp32_had = fp32_had

--- a/src/slicegpt/modules.py
+++ b/src/slicegpt/modules.py
@@ -15,9 +15,9 @@ class RMSN(torch.nn.Module):
     https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L75
     """
 
-    def __init__(self, mean_dim: int):
+    def __init__(self, mean_dim: int, eps: float = 1e-5):
         super().__init__()
-        self.eps = 1e-5
+        self.eps = eps
         self.mean_dim = mean_dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
This structure allows us to swap out modules like QuarotFP16* modules (which emulate INTX quantization in FP16) for real ones which use CUDA kernels, like Linear4bit.

It also gets rid of any monkeypatching business and is overall much clearer to model implementers, though for now this requires a fair bit of implementation.