### PR TITLE
QuaRot: cascade into quarot main

### DIFF
--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -161,12 +161,14 @@ def quarot_main(args: argparse.Namespace) -> None:
         model.cpu()
         utils.cleanup_memory()
 
-    # fuse layernorms
-    layernorm_fusion.fuse_modules(model_adapter)  # TODO: fix expected adapter type
-
     if args.rotate:
+        # fuse layernorms
+        layernorm_fusion.fuse_modules(model_adapter)  # TODO: fix expected adapter type
+
         # Rotate the model with fused Hadamard transformations.
         rotation.rotate_model(model_adapter, args.rotation_seed)
+    else:
+        raise NotImplementedError("Only with-rotation quantization is working right now.")  # TODO: fix
 
     model_config = QuarotLlamaConfig.from_pretrained(args.model, dtype=config.dtype)
     model_config._attn_implementation = "flash_attention_2"

--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -167,8 +167,6 @@ def quarot_main(args: argparse.Namespace) -> None:
 
         # Rotate the model with fused Hadamard transformations.
         rotation.rotate_model(model_adapter, args.rotation_seed)
-    else:
-        raise NotImplementedError("Only with-rotation quantization is working right now.")  # TODO: fix
 
     model_config = QuarotLlamaConfig.from_pretrained(args.model, dtype=config.dtype)
     model_config._attn_implementation = "flash_attention_2"
@@ -176,8 +174,9 @@ def quarot_main(args: argparse.Namespace) -> None:
         # initialize quarot model
         online_had_mlp = True if args.rotate else False
         online_had_attn = True if args.rotate else False
+        rms_norm = True if args.rotate else False
         quarot_llama = QuarotLlamaForCausalLM(
-            online_had_mlp=online_had_mlp, online_had_attn=online_had_attn, config=model_config
+            online_had_mlp=online_had_mlp, online_had_attn=online_had_attn, rms_norm=rms_norm, config=model_config
         )
 
         # load the rotated weights into the quarot model

--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -182,9 +182,9 @@ def quarot_main(args: argparse.Namespace) -> None:
         quarot_llama.load_state_dict(model_adapter.model.state_dict(), strict=False)
 
     if args.w_rtn:
-        print(f"Quantizing weights to INT{args.w_bits} using RTN.")
+        logging.info(f"Quantizing weights to INT{args.w_bits} using RTN.")
         rtn.quantize_model_rtn(quarot_llama, bits=args.w_bits)
-        print("Quantization complete.")
+        logging.info("Quantization complete.")
 
     quarot_llama.to(config.device)
     dataset_ppl = gpu_utils.evaluate_ppl(quarot_llama, quarot_llama.config.pad_token_id, test_loader)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,14 @@ dependencies = [
     "accelerate",
     "datasets==2.14.7",
     "einops",
-    "huggingface-hub==0.20.2",
+    "huggingface-hub==0.23.0",
     "lm-eval==0.4.1",
     "ml-collections",
     "numpy",
     "sentencepiece",
     "torch",
     "tqdm",
-    "transformers==4.37",
+    "transformers==4.41.0",
     "wandb",
 ]
 
@@ -49,7 +49,8 @@ finetune = [
 ]
 
 quarot = [
-    "fast_hadamard_transform",
+    "flash-attn==2.5.8",
+    "fast-hadamard-transform @ https://github.com/Dao-AILab/fast-hadamard-transform/archive/refs/tags/v1.0.4.post1.zip",
 ]
 
 [tool.setuptools.packages.find]
@@ -94,5 +95,6 @@ docstring-min-length = 10
 markers = [
     "gpu: tests that require GPU to run",
     "experiment: end to end experiments, slow to run",
-    "quarot: end to end quarot experiments, slow to run",
+    "quarot: unit tests, fast to run",
+    "quarot_experiment: end to end quarot experiments, slow to run",
 ]

--- a/src/quarot/__init__.py
+++ b/src/quarot/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 from .adapters.llama_adapter import LlamaModelAdapter
+from .adapters.phi3_adapter import Phi3ModelAdapter
 from .hadamard_utils import get_hadK
 from .hf_utils import get_model_and_tokenizer
 from .model_adapter import LayerAdapter, ModelAdapter

--- a/src/quarot/adapters/phi3_adapter.py
+++ b/src/quarot/adapters/phi3_adapter.py
@@ -1,0 +1,199 @@
+# coding=utf-8
+# Copyright 2024 Microsoft and the HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch import FloatTensor, Tensor
+from torch.nn import Linear, Module
+from transformers import PretrainedConfig
+from transformers.models.phi3.modeling_phi3 import Phi3Config, Phi3DecoderLayer, Phi3ForCausalLM, Phi3RMSNorm
+
+from quarot.model_adapter import LayerAdapter, ModelAdapter
+from quarot.nn.linear import QuarotFP16Linear
+
+
+class Phi3LayerAdapter(LayerAdapter):
+    def __init__(self, layer: Phi3DecoderLayer) -> None:
+        super().__init__()
+        self._layer: Phi3DecoderLayer = layer
+
+    @property
+    def layer(self) -> Module:
+        return self._layer
+
+    @property
+    def hidden_states_args_position(self) -> int:
+        return 0
+
+    @property
+    def hidden_states_output_position(self) -> int:
+        return 0
+
+    def get_first_layernorm(self) -> Module:
+        return self.layer.input_layernorm
+
+    def get_second_layernorm(self) -> Module:
+        return self.layer.post_attention_layernorm
+
+    def get_attention_inputs(self) -> list[Linear]:
+        return [self.layer.self_attn.qkv_proj]
+
+    def get_attention_output(self) -> Linear:
+        return self.layer.self_attn.o_proj
+
+    def get_mlp_inputs(self) -> list[Linear]:
+        return [self.layer.mlp.gate_up_proj]
+
+    def get_mlp_output(self) -> Linear:
+        return self.layer.mlp.down_proj
+
+    # QuaRot specific. NB diff behaviour to Llama2/3!
+    def get_v_proj(self) -> Linear:
+        qkv = self.layer.self_attn.qkv_proj
+        out_features, in_features = qkv.weight.shape
+        v_proj_out_features = out_features // 3
+        v_proj = QuarotFP16Linear(in_features, v_proj_out_features, bias=False)
+
+        # point v_proj weight to qkv weight
+        v_proj.weight = torch.nn.Parameter(qkv.weight[2 * v_proj_out_features :, :])
+        return v_proj
+
+
+class Phi3ModelAdapter(ModelAdapter):
+    def __init__(self, model: Phi3ForCausalLM) -> None:
+        super().__init__()
+        self._model: Phi3ForCausalLM = model
+
+    @property
+    def model(self) -> Module:
+        return self._model
+
+    @property
+    def config(self) -> PretrainedConfig:
+        return self._model.config
+
+    @property
+    def config_type(self) -> type:
+        return Phi3Config
+
+    @property
+    def parallel_blocks(self) -> bool:
+        return False
+
+    @property
+    def seqlen(self) -> int:
+        # if no sliding window, max_position_embeddings is same as original_max_position_embeddings
+        return self.config.max_position_embeddings
+
+    @property
+    def hidden_size(self) -> int:
+        return self.config.hidden_size
+
+    @property
+    def should_bake_mean_into_linear(self) -> bool:
+        return False
+
+    @property
+    def original_layer_type(self) -> type:
+        return Phi3DecoderLayer
+
+    @property
+    def original_layer_norm_type(self) -> type:
+        return Phi3RMSNorm
+
+    @property
+    def layer_adapter_type(self) -> type:
+        return Phi3LayerAdapter
+
+    # QuaRot specific
+    @property
+    def quarot_layer_type(self) -> type:
+        return Phi3DecoderLayer
+
+    @property
+    def use_cache(self) -> bool:
+        return self.config.use_cache
+
+    @use_cache.setter
+    def use_cache(self, value: bool) -> None:
+        self.config.use_cache = value
+
+    def compute_output_logits(self, input_ids: Tensor) -> FloatTensor:
+        return self.model(input_ids=input_ids).logits
+
+    def get_layers(self) -> list[LayerAdapter]:
+        return [self.layer_adapter_type(layer) for layer in self.model.model.layers]
+
+    def get_raw_layer_at(self, index: int) -> Module:
+        return self.model.model.layers[index]
+
+    def set_raw_layer_at(self, index: int, new_layer: Module) -> None:
+        self.model.model.layers[index] = new_layer
+
+    def get_embeddings(self) -> list[Module]:
+        return [self.model.model.embed_tokens]
+
+    def get_pre_head_layernorm(self) -> Module:
+        pre_head_layernorm = self.model.model.norm
+        assert isinstance(pre_head_layernorm, self.original_layer_norm_type)
+        return pre_head_layernorm
+
+    def get_lm_head(self) -> Linear:
+        return self.model.lm_head
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        model_name: str,
+        model_path: str,
+        *,
+        dtype: torch.dtype = torch.float16,
+        local_files_only: bool = False,
+        token: str | bool | None = None,
+    ) -> ModelAdapter | None:
+        if not model_name.startswith("microsoft/Phi-3-mini-4k-instruct"):
+            return None
+
+        model = Phi3ForCausalLM.from_pretrained(
+            model_path, torch_dtype=dtype, token=token, local_files_only=local_files_only
+        )
+        model.config.torch_dtype = dtype
+
+        return Phi3ModelAdapter(model)
+
+    @classmethod
+    def _from_uninitialized(
+        cls,
+        model_name: str,
+        model_path: str,
+        *,
+        dtype: torch.dtype = torch.float16,
+        local_files_only: bool = False,
+        token: str | bool | None = None,
+    ) -> ModelAdapter | None:
+        if not model_name.startswith("microsoft/Phi-3-mini-4k-instruct"):
+            return None
+
+        class UninitializedPhi3ForCausalLM(Phi3ForCausalLM):
+            def _init_weights(self, _) -> None:
+                # Prevent weight initialization
+                pass
+
+        config = Phi3Config.from_pretrained(
+            model_path, torch_dtype=dtype, token=token, local_files_only=local_files_only
+        )
+        model = UninitializedPhi3ForCausalLM(config)
+        model = model.to(dtype=dtype)
+
+        return Phi3ModelAdapter(model)

--- a/src/quarot/gptq.py
+++ b/src/quarot/gptq.py
@@ -1,0 +1,406 @@
+from typing import Any
+
+import torch
+from tqdm import tqdm
+
+from slicegpt.rotate import get_layer0_inputs
+from slicegpt.utils import cleanup_memory, map_tensors
+
+from .model_adapter import LayerAdapter, ModelAdapter
+from .nn.linear import QuarotFP16Linear
+from .quant_utils import PackedQuantizedTensor, dequantize
+from .rtn import calculate_scales, quantize_weight_rtn
+
+
+def gptq_quantize_column(i, col_idx, block_end_idx, W, Q, Err_block, L_inv_transpose, scale, offset, bits, symmetric):
+    """
+    Quantize one column of the weight matrix, W[:, col_idx]
+
+    i indexes the current position in the block.
+    """
+    # store the int-quantized weight column
+    Q[:, col_idx] = quantize_weight_rtn(W[:, col_idx : col_idx + 1], scale, offset, bits).flatten()
+
+    # calculate the dequantized weight
+    if symmetric:
+        W_dequantized = Q[:, col_idx] * scale.flatten()
+    else:
+        W_dequantized = (Q[:, col_idx] - offset.flatten()) * scale.flatten()
+
+    # calculate quantization error (between original and dequantized weight column)
+    Err_block[:, i] = (W[:, col_idx] - W_dequantized) / L_inv_transpose[col_idx, col_idx]
+
+    # update the rest of the weights in the block
+    W[:, col_idx:block_end_idx] -= (
+        Err_block[:, i : i + 1] * L_inv_transpose[col_idx : col_idx + 1, col_idx:block_end_idx]
+    )
+
+
+@torch.no_grad()
+def quantize_weight_gptq(
+    W: torch.Tensor,
+    H: torch.Tensor,
+    bits: int,
+    symmetric: bool = True,
+    max_blocksize: int = 128,
+    percdamp: float = 0.01,
+    groupsize: int | None = None,
+    clip_weights: bool = True,
+    optimize_scales: bool = True,
+    device='cuda',
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    """
+    Quantize a weight tensor to INT<bits> using the GPTQ scheme.
+
+    Args:
+        W: The weight tensor to quantize.
+        H: The Hessian of the activations, must have dtype==torch.float32.
+        bits: The number of bits to quantize to.
+        symmetric: Whether to use symmetric quantization.
+        max_blocksize: The maximum block size for the GPTQ algorithm.
+        percdamp: The damping factor for the Hessian.
+        groupsize: The number of weights to group together for quantization.
+        clip_weights: Whether to clip the weights (by searching for good clipping ratios) to the range of the quantization.
+    """
+    num_features, num_columns = W.shape
+    orig_dev = W.device
+    orig_dtype = W.dtype
+    W = W.to(device=device, dtype=torch.float32)
+    H = H.to(W.device, dtype=torch.float32)
+
+    # deal with group quantization.
+    # If groupsize is None, we quantize the entire tensor at once (there's a single scale and offset).
+    # otherwise, we collect the scale/offset for each group in a list
+    if groupsize is None:
+        scale, offset = calculate_scales(
+            W, bits, symmetric=symmetric, clip_weights=clip_weights, vectorized=False, device=device
+        )
+        scale = scale.float()
+        offset = offset.float() if offset is not None else None
+    else:
+        group_scales = []
+        group_offsets = []
+
+    # find dead weights and set them to zero, and their Hess value to 1
+    dead = torch.diag(H) == 0.0
+    H[dead, dead] = 1.0
+    W[:, dead] = 0.0
+
+    # add damping to the diagonal
+    H.diagonal().add_(percdamp * torch.mean(torch.diag(H)))
+
+    # calculate the inverse layer Hessian (Cholesky form).
+    # NB this is different to the original implementation. We require the (transpose) of the choleskyu of the _inverse_ of H.
+    # oringially this was done by chol(inv(H)). Here we do chol(H)^-1, with some re-ordering to ensure we get an equivalent solution.
+    # chol(inv(H), upper=True) = flip(inv(chol(flip(H), upper=False)))
+    # This version requires fewer flops and should be numerically superior.
+    PHP = torch.flip(H, (0, 1))
+    L = torch.linalg.cholesky(PHP)
+    L_inv = torch.linalg.solve_triangular(L, torch.eye(L.shape[0], device=L.device, dtype=L.dtype), upper=False)
+    L_inv_transpose = torch.flip(L_inv, (0, 1))
+
+    Q = torch.zeros_like(W)
+    for block_start_idx in range(0, num_columns, max_blocksize):
+        block_end_idx = min(block_start_idx + max_blocksize, num_columns)
+        blocksize = block_end_idx - block_start_idx
+
+        Err_block = torch.zeros((W.shape[0], blocksize), dtype=W.dtype, device=W.device)
+
+        for i in range(blocksize):  # i = which col to quantize (wrt block)
+            col_idx = block_start_idx + i  # which ciolumn to quantize (wrt original matrix)
+
+            # if this is a new group, calculate the scales for the group
+            if groupsize is not None and col_idx % groupsize == 0:
+                scale, offset = calculate_scales(
+                    W[:, col_idx : col_idx + groupsize],
+                    bits,
+                    symmetric=symmetric,
+                    clip_weights=clip_weights,
+                    vectorized=False,
+                    device=device,
+                )
+                scale = scale.float()
+                offset = offset.float() if offset is not None else None
+                group_scales.append(scale)
+                group_offsets.append(offset)
+
+            gptq_quantize_column(
+                i, col_idx, block_end_idx, W, Q, Err_block, L_inv_transpose, scale, offset, bits, symmetric
+            )
+
+        # update the rest of the weights in the tensor
+        W[:, block_end_idx:] -= Err_block @ L_inv_transpose[block_start_idx:block_end_idx, block_end_idx:]
+
+    # stack the scales for grouped quantization
+    if groupsize is not None:
+        scale = torch.cat(group_scales, dim=1)
+        offset = torch.cat(group_offsets, dim=1) if group_offsets[0] is not None else None
+
+    # if optimize_scales is True, solve for the optimal scaling factors
+    if optimize_scales:
+        scale = solve_optimal_scales(W, Q, H, groupsize=groupsize, offset=offset)
+
+    # move back to original device and dtype
+    Q = Q.to(orig_dev, dtype=orig_dtype)
+    scale = scale.to(orig_dev, dtype=orig_dtype)
+    if not symmetric:
+        offset = offset.to(orig_dev, dtype=orig_dtype)
+
+    return Q, scale, offset
+
+
+def solve_optimal_scales(W, W_int, H, groupsize=None, offset=None):
+    """
+    Given a weight matrix W, and its quantized version W_int, solve for the optimal scaling factors.
+
+    Note that the _optimal_ scaling factors are not necessarily the same as the ones used in the quantization process. To derive this, consider the GPTQ loss function:
+
+      W_recon = (W_int - offset) * scale
+      L = trace( [W - W_recon] H [W - W_recon]^T )
+
+    differentiate with respect to scale, set to zero, and solve for scale, being careful of the tiling used in reconstructing across groups.
+    """
+    assert W.shape == W_int.shape
+    assert len(W.shape) == 2
+    num_cols = W.shape[1]
+    assert H.shape[0] == H.shape[1] == num_cols
+    if groupsize is None:
+        groupsize = num_cols
+    assert num_cols % groupsize == 0
+    num_groups = num_cols // groupsize
+    scales = []
+    if offset is not None:
+        W_int = W_int - torch.repeat_interleave(offset, groupsize, dim=1)
+    for wh_i, w_int_i in zip(W @ H, W_int):
+        rhs = (w_int_i * wh_i).view(num_groups, groupsize).sum(dim=1)
+        mat = H * w_int_i * w_int_i[:, None]
+        mat = mat.view(num_cols, num_groups, groupsize).sum(dim=2).view(num_cols, num_groups)
+        mat = mat.T.view(num_groups, num_groups, groupsize).sum(dim=2)
+        scales.append(torch.linalg.solve(mat, rhs))
+    scales = torch.stack(scales)
+    return scales
+
+
+def construct_hessian(
+    X: list[torch.Tensor | PackedQuantizedTensor], ignore_masks: list[torch.Tensor] | None = None
+) -> torch.Tensor:
+    """
+    Construct the Hessian matrix for a given set of activations.
+    """
+    # Run GC and cleanup GPU memory
+    cleanup_memory()
+
+    if isinstance(X[0], PackedQuantizedTensor):
+        X = [x.quantized_x for x in X]
+
+    H = None
+    num_samples = 0
+    hidden_dim = X[0].shape[-1]
+    H = torch.zeros(hidden_dim, hidden_dim, device='cuda')
+    for idx, X_batch in enumerate(X):
+        batch_size, seq_len = X_batch.shape[:2]
+        if ignore_masks:
+            X_batch[ignore_masks[idx] == 0] = 0
+            num_elements = ignore_masks[idx].sum()
+        else:
+            num_elements = batch_size * seq_len
+
+        X_batch = X_batch.to('cuda', dtype=torch.float32) * torch.rsqrt(torch.tensor(num_elements, device='cuda'))
+        H_batch = torch.einsum('bld,blc->dc', X_batch, X_batch)
+        H = H * (num_samples / (num_samples + num_elements)) + H_batch * (num_elements / (num_samples + num_elements))
+        num_samples += num_elements
+
+    return H
+
+
+@torch.no_grad()
+def get_signals(
+    layer_adapter: LayerAdapter, layer_args: list[tuple], layer_kwargs: list[dict[str, Any]]
+) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor], list[torch.Tensor], list[torch.Tensor]]:
+    """
+    Take the input signals ("activations") for a layer, run the layer forward.
+    Return the output of the layer and the inputs to the attention inputs & output, and to the mlp inputs & output.
+    """
+    qkv_inputs, o_proj_inputs, upgate_inputs, down_proj_inputs = [], [], [], []
+    outputs = []
+    device = 'cuda'
+    layer_adapter.layer.to(device)
+
+    def make_hook(storage_list):
+        def hook_fn(_, args: tuple, _output: Any) -> None:
+            storage_list.append(args[0])
+
+        return hook_fn
+
+    hooks = [make_hook(qkv_inputs), make_hook(o_proj_inputs), make_hook(upgate_inputs), make_hook(down_proj_inputs)]
+    modules = [
+        layer_adapter.get_attention_inputs()[0],
+        layer_adapter.get_attention_output(),
+        layer_adapter.get_mlp_inputs()[0],
+        layer_adapter.get_mlp_output(),
+    ]
+    hooks = [m.register_forward_hook(h) for m, h in zip(modules, hooks)]
+
+    for layer_args_batch, layer_kwargs_batch in zip(layer_args, layer_kwargs):
+        layer_args_batch, layer_kwargs_batch = map_tensors([layer_args_batch, layer_kwargs_batch], device=device)
+        out = layer_adapter.layer(*layer_args_batch, **layer_kwargs_batch)
+        if isinstance(out, tuple):
+            out = out[layer_adapter.hidden_states_output_position]
+        outputs.append(out)
+
+    for h in hooks:
+        h.remove()
+
+    return qkv_inputs, o_proj_inputs, upgate_inputs, down_proj_inputs, outputs
+
+
+def set_tensors(
+    module: torch.nn.Linear | QuarotFP16Linear,
+    quantized_weight: torch.Tensor,
+    scale: torch.Tensor,
+    offset: torch.Tensor | None = None,
+) -> None:
+    """
+    Set the quantized weight, scale, and offset into a module. If the module is a torch.nn.Linear, the weight is dequantized using the scale and offset.
+    Otherwise if it is a QuarotFP16Linear, the weight buffer is set to be equal to quantized_weight - offset, and the weight scale buffer is equal to the given scale.
+    """
+    out_features, in_features = module.weight.data.shape
+    assert quantized_weight.shape == (out_features, in_features)
+    assert scale.shape[0] == out_features
+    if offset is not None:
+        assert offset.shape == scale.shape
+
+    if isinstance(module, QuarotFP16Linear):
+        module.weight.data = quantized_weight  # out_features x in_features
+        module.weight_scales.data = scale  # out_features x num_groups
+        if offset is not None:
+            module.offset.data = offset
+    elif isinstance(module, torch.nn.Linear):
+        module.weight.data = dequantize(quantized_weight, scale, offset)
+    else:
+        raise ValueError(f"Unsupported module type {type(module)}")
+
+
+def quantize_model_gptq(
+    model_adapter: ModelAdapter,
+    dataloader: torch.utils.data.DataLoader[torch.Tensor],
+    bits: int,
+    symmetric: bool = True,
+    apply_mask: bool = False,
+    damping: float = 0.01,
+    groupsize: int = None,
+    optimize_scales: bool = True,
+) -> None:
+    """
+    Quantize the model in-place using the GPTQ scheme, using the dataloader calibration data. All weights are stored in FP16.
+    If the model is a QuaRot model, the weights-minus-offsets and scales are stored in the QuarotFP16Linear modules. If the model is not a QuaRot model,
+    the weights are dequantized and stored in the torch.nn.Linear modules.
+
+    Arguments:
+    - model_adapter: the model adapter to quantize.
+    - dataloader: the dataloader to use for calibration.
+    - bits: the number of bits to quantize to.
+    - symmetric: whether to use symmetric quantization.
+    - apply_mask: whether to apply the attention mask to the activations.
+    - damping: the damping factor for the Hessian.
+    - groupsize: the group size for quantization.
+    - optimize_scales: whether to optimize the scaling factors after quantization.
+    """
+    model_adapter.model.eval()
+
+    inps, args, kwargs, ignore_masks = [], [], [], []
+    for batch in dataloader:
+        inp_batch, args_batch, kwargs_batch = get_layer0_inputs(model_adapter, batch)
+        inps.append(inp_batch)
+        args.append(args_batch)
+        kwargs.append(kwargs_batch)
+        if apply_mask:
+            ignore_masks.append(batch["attention_mask"])
+
+    for layer_adapter in tqdm(model_adapter.get_layers(), unit="layer", desc="Quantizing layer"):
+        layer_adapter.layer.to('cuda')
+
+        # get all activations for the current layer (4 sets)
+        qkv_inputs, o_proj_inputs, upgate_inputs, down_proj_inputs, outputs = get_signals(layer_adapter, args, kwargs)
+
+        # compute the 4 Hessians
+        H_qkv, H_o_proj, H_upgate, H_down_proj = [
+            construct_hessian(X, ignore_masks) for X in [qkv_inputs, o_proj_inputs, upgate_inputs, down_proj_inputs]
+        ]
+
+        # get 4 weight matrices (concat as needed)
+        W_qkv = torch.cat([w.weight.data for w in layer_adapter.get_attention_inputs()], dim=0)
+        W_o_proj = layer_adapter.get_attention_output().weight.data
+        W_upgate = torch.cat([w.weight.data for w in layer_adapter.get_mlp_inputs()], dim=0)
+        W_down_proj = layer_adapter.get_mlp_output().weight.data
+
+        # 4 calls to quantizer
+        Q_qkv, scale_qkv, offset_qkv = quantize_weight_gptq(
+            W_qkv,
+            H_qkv,
+            bits,
+            symmetric=symmetric,
+            percdamp=damping,
+            groupsize=groupsize,
+            optimize_scales=optimize_scales,
+        )
+        Q_o_proj, scale_o_proj, offset_o_proj = quantize_weight_gptq(
+            W_o_proj,
+            H_o_proj,
+            bits,
+            symmetric=symmetric,
+            percdamp=damping,
+            groupsize=groupsize,
+            optimize_scales=optimize_scales,
+        )
+        Q_upgate, scale_upgate, offset_upgate = quantize_weight_gptq(
+            W_upgate,
+            H_upgate,
+            bits,
+            symmetric=symmetric,
+            percdamp=damping,
+            groupsize=groupsize,
+            optimize_scales=optimize_scales,
+        )
+        Q_down_proj, scale_down_proj, offset_down_proj = quantize_weight_gptq(
+            W_down_proj,
+            H_down_proj,
+            bits,
+            symmetric=symmetric,
+            percdamp=damping,
+            groupsize=groupsize,
+            optimize_scales=optimize_scales,
+        )
+
+        # set the quantized weights and scales of the attention inputs
+        attn_inputs = layer_adapter.get_attention_inputs()
+        for module, quantized_weight, scale, offset in zip(
+            attn_inputs,
+            torch.chunk(Q_qkv, len(attn_inputs), dim=0),
+            torch.chunk(scale_qkv, len(attn_inputs), dim=0),
+            torch.chunk(offset_qkv, len(attn_inputs), dim=0) if offset_qkv is not None else [None] * len(attn_inputs),
+        ):
+            set_tensors(module, quantized_weight, scale, offset)
+
+        # set the quantized weights and scales of the attention output
+        set_tensors(layer_adapter.get_attention_output(), Q_o_proj, scale_o_proj, offset_o_proj)
+
+        # set the quantized weights and scales of the MLP inputs
+        mlp_inputs = layer_adapter.get_mlp_inputs()
+        for module, quantized_weight, scale, offset in zip(
+            mlp_inputs,
+            torch.chunk(Q_upgate, len(mlp_inputs), dim=0),
+            torch.chunk(scale_upgate, len(mlp_inputs), dim=0),
+            torch.chunk(offset_upgate, len(mlp_inputs), dim=0)
+            if offset_upgate is not None
+            else [None] * len(mlp_inputs),
+        ):
+            set_tensors(module, quantized_weight, scale, offset)
+
+        # set the quantized weights and scales of the MLP output
+        set_tensors(layer_adapter.get_mlp_output(), Q_down_proj, scale_down_proj, offset_down_proj)
+
+        # outputs of this layer are inputs of the next
+        args = [layer_adapter.get_updated_args(output_i, args_i) for output_i, args_i in zip(outputs, args)]
+
+        layer_adapter.layer.to('cpu')

--- a/src/quarot/hadamard_utils.py
+++ b/src/quarot/hadamard_utils.py
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import math
-
 import torch
 
 from .hadamard_tensors import (
@@ -134,35 +132,50 @@ def apply_hadamard_headwise(module: torch.nn.Linear, head_dim: int):
     - module: the torch.nn.Linear instance to modify.
     - head_dim: the head dimension. Must be a power of 2.
     """
-    assert is_pow2(head_dim), "Head dimension must be a power of 2!"
+    W_ = module.weight.data
 
-    W_ = module.weight.data.t()
     dtype = W_.dtype
     dev = W_.device
     W_ = W_.float().cuda()
 
-    scale = 1 / math.sqrt(head_dim)
-    num_heads = module.out_features // head_dim
-    W_ = hadamard_transform(W_.reshape(module.in_features, num_heads, head_dim), scale=scale)
-    W_ = W_.reshape((module.in_features, module.out_features)).t()
+    out_features, in_features = W_.shape
+    num_heads = out_features // head_dim
+    W_ = W_.t()  # (in_features, out_features)
+    W_ = W_.reshape(in_features, num_heads, head_dim)  # (in_features, num_heads, head_dim)
+    W_ = factored_hadamard(W_)  # hadamard along the head dimension
+    W_ = W_.reshape((in_features, out_features)).t()  # (out_features, in_features)
 
-    module.weight.data = W_.to(device=dev, dtype=dtype)
+    module.weight.data[:, :] = W_.to(device=dev, dtype=dtype)[
+        :, :
+    ]  # in-place replacement needed when updating v_proj in Phi3 so that parent qkv is updated
 
 
-def apply_hadamard(module: torch.nn.Linear) -> None:
+def apply_hadamard(module: torch.nn.Linear, head_dim: int | None = None) -> None:
     """
     Modifies the weights contained in a torch.nn.Linear instance. If the weights are W,
     this turns them into HW, where H is a Hadamard matrix.
 
     Args:
     - module: the torch.nn.Linear instance to modify.
+    - head_dim: the head dimension (if applicable). If provided, the Hadamard transform is applied headwise (default: None).
     """
     W_ = module.weight.data
     dtype = W_.dtype
     dev = W_.device
     W_ = W_.float().cuda()
 
-    W_ = factored_fast_hadamard(W_) if fht_available else factored_slow_hadamard(W_)
+    out_features, in_features = W_.shape
+    if head_dim is not None and not is_pow2(in_features):
+        num_heads = in_features // head_dim
+        W_ = W_.reshape(out_features, num_heads, head_dim)
+        W_ = factored_hadamard(W_)
+        W_ = W_.mT
+        W_ = factored_hadamard(W_)
+        W_ = W_.mT
+        W_ = W_.reshape(out_features, in_features)
+    else:
+        W_ = factored_fast_hadamard(W_) if fht_available else factored_slow_hadamard(W_)
+
     module.weight.data = W_.to(device=dev, dtype=dtype)
 
 
@@ -177,5 +190,5 @@ def random_hadamard_matrix(size: int, seed: int = 0) -> torch.Tensor:
     return factored_slow_hadamard(Q)
 
 
-def is_pow2(n):
+def is_pow2(n: int) -> bool:
     return (n & (n - 1) == 0) and (n > 0)

--- a/src/quarot/hadamard_utils.py
+++ b/src/quarot/hadamard_utils.py
@@ -115,11 +115,12 @@ def _apply_fast_hadamard(X: torch.tensor, hadK: torch.tensor) -> torch.tensor:
     n = X.shape[-1]
     K = hadK.shape[0]
     scale = 1.0 / torch.tensor(n).sqrt()
+    X = X.contiguous()
     if K == 1:
-        return hadamard_transform(X.contiguous(), scale)
+        return hadamard_transform(X, scale)
 
     input = X.view(-1, K, n // K)
-    input = hadamard_transform(input.contiguous(), scale)
+    input = hadamard_transform(input, scale)
     input = hadK.to(input.device).to(input.dtype) @ input
     return input.reshape(X.shape)
 

--- a/src/quarot/hf_utils.py
+++ b/src/quarot/hf_utils.py
@@ -5,11 +5,73 @@ import logging
 import pathlib
 
 import torch
-from transformers import AutoTokenizer, PreTrainedTokenizerBase
+from transformers import AutoTokenizer, PretrainedConfig, PreTrainedTokenizerBase
 
 from slicegpt.hf_utils import do_not_initialize
 
 from .model_adapter import ModelAdapter
+from .modeling_llama import QuarotLlamaConfig, QuarotLlamaForCausalLM
+from .modeling_phi3 import QuarotPhi3Config, QuarotPhi3ForCausalLM
+
+
+def quarot_model_config(
+    model_name_or_path: str, dtype: torch.dtype, groupsize: int | None = None, offset: bool = False
+):
+    if model_name_or_path in ['meta-llama/Llama-2-7b-hf', 'meta-llama/Llama-2-13b-hf']:
+        model_config = QuarotLlamaConfig.from_pretrained(model_name_or_path, dtype=dtype, use_cache=False)
+    elif model_name_or_path == 'microsoft/Phi-3-mini-4k-instruct':
+        model_config = QuarotPhi3Config.from_pretrained(model_name_or_path, dtype=dtype, use_cache=False)
+    else:
+        raise NotImplementedError("Model type not supported")
+    model_config._attn_implementation = "flash_attention_2"
+    model_config.groupsize = groupsize
+    model_config.offset = offset
+    return model_config
+
+
+def get_quarot_model(
+    model_name_or_path: str,
+    rotate: bool,
+    act_args: dict,
+    key_args: dict,
+    value_args: dict,
+    model_config: PretrainedConfig,
+):
+    online_had_mlp = True if rotate else False
+    online_had_attn = True if rotate else False
+    rms_norm = True if rotate else False
+    if model_name_or_path in ['meta-llama/Llama-2-7b-hf', 'meta-llama/Llama-2-13b-hf']:
+        return QuarotLlamaForCausalLM(
+            online_had_mlp=online_had_mlp,
+            online_had_attn=online_had_attn,
+            rms_norm=rms_norm,
+            act_bits=act_args['a_bits'],
+            act_clip_ratio=act_args['a_clip_ratio'],
+            k_bits=key_args['k_bits'],
+            k_clip_ratio=key_args['k_clip_ratio'],
+            k_groupsize=key_args['k_groupsize'],
+            v_bits=value_args['v_bits'],
+            v_clip_ratio=value_args['v_clip_ratio'],
+            v_groupsize=value_args['v_groupsize'],
+            config=model_config,
+        )
+    elif model_name_or_path == 'microsoft/Phi-3-mini-4k-instruct':
+        return QuarotPhi3ForCausalLM(
+            online_had_mlp=online_had_mlp,
+            online_had_attn=online_had_attn,
+            rms_norm=rms_norm,
+            act_bits=act_args['a_bits'],
+            act_clip_ratio=act_args['a_clip_ratio'],
+            k_bits=key_args['k_bits'],
+            k_clip_ratio=key_args['k_clip_ratio'],
+            k_groupsize=key_args['k_groupsize'],
+            v_bits=value_args['v_bits'],
+            v_clip_ratio=value_args['v_clip_ratio'],
+            v_groupsize=value_args['v_groupsize'],
+            config=model_config,
+        )
+    else:
+        raise NotImplementedError("Model type not supported")
 
 
 @do_not_initialize

--- a/src/quarot/modeling_phi3.py
+++ b/src/quarot/modeling_phi3.py
@@ -1,20 +1,30 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT license.
+# coding=utf-8
+# Copyright 2024 Microsoft and the HuggingFace Inc. team. All rights reserved.
 #
-# This file contains derivations from
-# https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py
-# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
-# https://www.apache.org/licenses/LICENSE-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" PyTorch Phi-3 model."""
 
 from typing import Optional, Tuple
 
 import torch
-from transformers import Cache, LlamaConfig
-from transformers.models.llama.modeling_llama import (
-    LlamaFlashAttention2,
-    LlamaForCausalLM,
-    LlamaMLP,
+from transformers import Cache, Phi3Config
+from transformers.models.phi3.modeling_phi3 import (
+    Phi3FlashAttention2,
+    Phi3ForCausalLM,
+    Phi3MLP,
     apply_rotary_pos_emb,
+    repeat_kv,
 )
 from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
 
@@ -25,17 +35,22 @@ from .nn.quantizer import ActQuantizer, DummyActQuantizer, KVQuantizerDequantize
 
 ALL_LAYERNORM_LAYERS.append(RMSN)
 
+try:
+    from transformers.models.phi3.modeling_phi3 import _flash_supports_window_size
+except ImportError:
+    _flash_supports_window_size = False
 
-class QuarotLlamaConfig(LlamaConfig):
-    model_type = "llama_quarot"
+
+class QuarotPhi3Config(Phi3Config):
+    model_type = "phi3_quarot"
     groupsize = None
     offset = False
 
 
-class QuarotLlamaMLP(LlamaMLP):
+class QuarotPhi3MLP(Phi3MLP):
     def __init__(
         self,
-        config: QuarotLlamaConfig,
+        config: QuarotPhi3Config,
         act_bits: int = 16,
         act_clip_ratio: float = 1.0,
         online_had: bool = False,
@@ -44,10 +59,9 @@ class QuarotLlamaMLP(LlamaMLP):
     ):
         super().__init__(config, *args, **kwargs)
         self.online_had = online_had
-        self.up_proj = QuarotFP16Linear.like(self.up_proj, groupsize=config.groupsize, offset=config.offset)
-        self.gate_proj = QuarotFP16Linear.like(self.gate_proj, groupsize=config.groupsize, offset=config.offset)
+        self.gate_up_proj = QuarotFP16Linear.like(self.gate_up_proj, groupsize=config.groupsize, offset=config.offset)
         self.down_proj = QuarotFP16Linear.like(self.down_proj, groupsize=config.groupsize, offset=config.offset)
-        self.online_down_proj_hadamard = OnlineHadamard(self.intermediate_size)
+        self.online_down_proj_hadamard = OnlineHadamard(config.intermediate_size)
         if act_bits < 16:
             self.input_quantizer = ActQuantizer(act_bits, symmetric=True, clip_ratio=act_clip_ratio)
             self.down_proj_input_quantizer = ActQuantizer(act_bits, symmetric=True, clip_ratio=act_clip_ratio)
@@ -60,7 +74,9 @@ class QuarotLlamaMLP(LlamaMLP):
         x = self.input_quantizer(x)
 
         # Calculate activations
-        x = self.act_fn(self.gate_proj(x)) * self.up_proj(x)
+        x = self.gate_up_proj(x)
+        gate, x = x.chunk(2, dim=-1)
+        x = x * self.activation_fn(gate)
 
         # Apply online hadamard if needed
         if self.online_had:
@@ -73,10 +89,10 @@ class QuarotLlamaMLP(LlamaMLP):
         return self.down_proj(x)
 
 
-class QuarotFP16LlamaFlashAttention2(LlamaFlashAttention2):
+class QuarotFP16Phi3FlashAttention2(Phi3FlashAttention2):
     def __init__(
         self,
-        config: QuarotLlamaConfig,
+        config: QuarotPhi3Config,
         act_bits: int = 16,
         act_clip_ratio: float = 1.0,
         k_bits: int = 16,
@@ -91,9 +107,7 @@ class QuarotFP16LlamaFlashAttention2(LlamaFlashAttention2):
     ):
         super().__init__(config, *args, **kwargs)
         self.online_had = online_had
-        self.q_proj = QuarotFP16Linear.like(self.q_proj, groupsize=config.groupsize, offset=config.offset)
-        self.k_proj = QuarotFP16Linear.like(self.k_proj, groupsize=config.groupsize, offset=config.offset)
-        self.v_proj = QuarotFP16Linear.like(self.v_proj, groupsize=config.groupsize, offset=config.offset)
+        self.qkv_proj = QuarotFP16Linear.like(self.qkv_proj, groupsize=config.groupsize, offset=config.offset)
         self.o_proj = QuarotFP16Linear.like(self.o_proj, groupsize=config.groupsize, offset=config.offset)
         self.online_o_proj_hadamard = OnlineHadamard(self.num_heads)
         self.online_k_hadamard = OnlineHadamard(self.head_dim)
@@ -128,9 +142,12 @@ class QuarotFP16LlamaFlashAttention2(LlamaFlashAttention2):
         past_key_value: Optional[Cache] = None,
         output_attentions: bool = False,
         use_cache: bool = False,
-        cache_position: Optional[torch.LongTensor] = None,
-        **kwargs,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        # Phi3FlashAttention2 attention does not support output_attentions
+
+        if not _flash_supports_window_size:
+            raise ValueError("The current flash attention version does not support sliding window attention.")
+
         output_attentions = False
 
         bsz, q_len, _ = hidden_states.size()
@@ -138,23 +155,36 @@ class QuarotFP16LlamaFlashAttention2(LlamaFlashAttention2):
         # QuaRot: quantize hidden states at input of attention
         hidden_states = self.input_quantizer(hidden_states)
 
-        query_states = self.q_proj(hidden_states)
-        key_states = self.k_proj(hidden_states)
-        value_states = self.v_proj(hidden_states)
+        qkv = self.qkv_proj(hidden_states)
+        query_pos = self.num_heads * self.head_dim
+        query_states = qkv[..., :query_pos]
+        key_states = qkv[..., query_pos : query_pos + self.num_key_value_heads * self.head_dim]
+        value_states = qkv[..., query_pos + self.num_key_value_heads * self.head_dim :]
 
         # Flash attention requires the input to have the shape
         # batch_size x seq_length x head_dim x hidden_dim
         # therefore we just need to keep the original shape
-        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim)  # QuaRot: remove transpose
-        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim)  # QuaRot: remove transpose
-        value_states = value_states.view(
-            bsz, q_len, self.num_key_value_heads, self.head_dim
-        )  # QuaRot: remove transpose
+        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim)
+        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim)
+        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim)
 
-        cos, sin = self.rotary_emb(value_states, position_ids)
+        kv_seq_len = key_states.shape[1]
+        if past_key_value is not None:
+            if self.layer_idx is None:
+                raise ValueError(
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__} "
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
+                    "with a layer index."
+                )
+            kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
+
+        # Because the input can be padded, the absolute sequence length depends on the max position id.
+        rotary_seq_len = max(kv_seq_len, position_ids[:, -1].max().item()) + 1
+        cos, sin = self.rotary_emb(value_states, position_ids, seq_len=rotary_seq_len)
+
         query_states, key_states = apply_rotary_pos_emb(
-            query_states, key_states, cos, sin, unsqueeze_dim=2
-        )  # QuaRot: requires unsqueeze
+            query_states, key_states, cos, sin, position_ids, unsqueeze_dim=2
+        )
 
         # QuaRot: apply online hadamard to queries and keys
         if self.online_had:
@@ -165,13 +195,74 @@ class QuarotFP16LlamaFlashAttention2(LlamaFlashAttention2):
         key_states = self.k_quantizer(key_states)
         value_states = self.v_quantizer(value_states)
 
+        use_sliding_windows = (
+            _flash_supports_window_size
+            and getattr(self.config, "sliding_window", None) is not None
+            and kv_seq_len > self.config.sliding_window
+        )
+
         if past_key_value is not None:
-            # sin and cos are specific to RoPE models; position_ids needed for the static cache
-            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position, "attention_mask": attention_mask}
+            # Activate slicing cache only if the config has a value `sliding_windows` attribute
+            cache_has_contents = past_key_value.get_seq_length(self.layer_idx) > 0
+            if (
+                getattr(self.config, "sliding_window", None) is not None
+                and kv_seq_len > self.config.sliding_window
+                and cache_has_contents
+            ):
+                slicing_tokens = 1 - self.config.sliding_window
+
+                past_key = past_key_value[self.layer_idx][0]
+                past_value = past_key_value[self.layer_idx][1]
+
+                past_key = past_key[:, :, slicing_tokens:, :].contiguous()
+                past_value = past_value[:, :, slicing_tokens:, :].contiguous()
+
+                if past_key.shape[-2] != self.config.sliding_window - 1:
+                    raise ValueError(
+                        f"past key must have a shape of (`batch_size, num_heads, self.config.sliding_window-1, head_dim`), got"
+                        f" {past_key.shape}"
+                    )
+
+                if attention_mask is not None:
+                    attention_mask = attention_mask[:, slicing_tokens:]
+                    attention_mask = torch.cat([attention_mask, torch.ones_like(attention_mask[:, -1:])], dim=-1)
+
+            cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
+        # repeat k/v heads if n_kv_heads < n_heads
+        key_states = repeat_kv(key_states, self.num_key_value_groups)
+        value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+        attn_dropout = self.attention_dropout if self.training else 0.0
+
+        # In PEFT, usually we cast the layer norms in float32 for training stability reasons
+        # therefore the input hidden states gets silently casted in float32. Hence, we need
+        # cast them back in the correct dtype just to be sure everything works as expected.
+        # This might slowdown training & inference so it is recommended to not cast the LayerNorms
+        # in fp32.
+
+        if query_states.dtype == torch.float32:
+            if torch.is_autocast_enabled():
+                target_dtype = torch.get_autocast_gpu_dtype()
+            # Handle the case where the model is quantized
+            elif hasattr(self.config, "_pre_quantization_dtype"):
+                target_dtype = self.config._pre_quantization_dtype
+            else:
+                target_dtype = self.qkv_proj.weight.dtype
+
+            query_states = query_states.to(target_dtype)
+            key_states = key_states.to(target_dtype)
+            value_states = value_states.to(target_dtype)
+
         attn_output = self._flash_attention_forward(
-            query_states, key_states, value_states, query_length=q_len, attention_mask=attention_mask
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            q_len,
+            dropout=attn_dropout,
+            use_sliding_windows=use_sliding_windows,
         )
 
         # QuaRot: apply online hadamard if needed
@@ -190,7 +281,7 @@ class QuarotFP16LlamaFlashAttention2(LlamaFlashAttention2):
         return attn_output, attn_weights, past_key_value
 
 
-class QuarotLlamaForCausalLM(LlamaForCausalLM):
+class QuarotPhi3ForCausalLM(Phi3ForCausalLM):
     def __init__(
         self,
         online_had_mlp: bool = False,
@@ -204,7 +295,7 @@ class QuarotLlamaForCausalLM(LlamaForCausalLM):
         v_bits: int = 16,
         v_clip_ratio: float = 1.0,
         v_groupsize: int | None = None,
-        config: QuarotLlamaConfig = None,
+        config: QuarotPhi3Config = None,
     ) -> None:
         """
         Args:
@@ -219,7 +310,7 @@ class QuarotLlamaForCausalLM(LlamaForCausalLM):
             self.model.norm = RMSN(config.hidden_size, eps=config.rms_norm_eps)
 
         for layer_idx, layer in enumerate(self.model.layers):
-            layer.self_attn = QuarotFP16LlamaFlashAttention2(
+            layer.self_attn = QuarotFP16Phi3FlashAttention2(
                 config=config,
                 act_bits=act_bits,
                 act_clip_ratio=act_clip_ratio,
@@ -232,7 +323,7 @@ class QuarotLlamaForCausalLM(LlamaForCausalLM):
                 online_had=online_had_attn,
                 layer_idx=layer_idx,
             )
-            layer.mlp = QuarotLlamaMLP(
+            layer.mlp = QuarotPhi3MLP(
                 config=config, act_bits=act_bits, act_clip_ratio=act_clip_ratio, online_had=online_had_mlp
             )
             if rms_norm:

--- a/src/quarot/nn/__init__.py
+++ b/src/quarot/nn/__init__.py
@@ -1,3 +1,2 @@
 from .hadamard import OnlineHadamard
 from .linear import QuarotFP16Linear
-from .quantizer import DummyActQuantizer

--- a/src/quarot/nn/hadamard.py
+++ b/src/quarot/nn/hadamard.py
@@ -1,16 +1,16 @@
 import torch
 
-from quarot.hadamard_utils import _apply_fast_hadamard, _apply_slow_hadamard, fht_available, get_hadK
+from ..hadamard_utils import _apply_fast_hadamard, _apply_slow_hadamard, fht_available, get_hadK
 
 
 class OnlineHadamard(torch.nn.Module):
     def __init__(self, hadamard_dim, force_fp32=False):
         super().__init__()
         self.fp32_had = force_fp32
-        had_rem_dim = get_hadK(hadamard_dim)
-        self.register_buffer("had_rem_dim", had_rem_dim)
+        had_tensor = get_hadK(hadamard_dim)
+        self.register_buffer("had_tensor", had_tensor)
         if not self.fp32_had:
-            self.had_rem_dim = self.had_rem_dim.to(torch.float16)
+            self.had_tensor = self.had_tensor.to(torch.float16)
 
         if fht_available:
             self.had = _apply_fast_hadamard
@@ -22,7 +22,7 @@ class OnlineHadamard(torch.nn.Module):
         if self.fp32_had:
             x = x.float()
 
-        x = self.had(x, self.had_rem_dim)  # NB this uses a CUDA kernel from fast_hadamard_transform
+        x = self.had(x, self.had_tensor)  # NB this uses a CUDA kernel from fast_hadamard_transform
 
         x = x.to(x_dtype)
         return x

--- a/src/quarot/nn/linear.py
+++ b/src/quarot/nn/linear.py
@@ -24,7 +24,7 @@ class QuarotFP16Linear(torch.nn.Module):
 
         # Perform matmul by first de-quantizing the activations and weights, and then multiplying.
         # This is done for numerical stability. Note that in real quantization, the quantized weights and activations
-        # would be multiplied first using kernels, and then by the scales. 
+        # would be multiplied first using kernels, and then by the scales.
         x = (x * scales_x) @ (self.weight.T * self.weight_scales.T)
 
         if self.bias is not None:

--- a/src/quarot/nn/linear.py
+++ b/src/quarot/nn/linear.py
@@ -1,6 +1,6 @@
 import torch
 
-from quarot.quant_utils import PackedQuantizedTensor
+from ..quant_utils import PackedQuantizedTensor, dequantize
 
 
 class QuarotFP16Linear(torch.nn.Module):
@@ -8,36 +8,53 @@ class QuarotFP16Linear(torch.nn.Module):
     Linear module for emulating quantized weights and activations. All tensors are stored in FP16.
     """
 
-    def __init__(self, in_features, out_features, bias=False, dtype=torch.float16):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+        offset: bool = False,
+        group_size: int = None,
+        dtype=torch.float16,
+    ):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
-        self.register_buffer('weight_scales', torch.ones((self.out_features, 1), dtype=dtype))
+
+        # figure out group size
+        if group_size is None:
+            group_size = in_features  # tensor-level scaling, one effective group
+        assert in_features % group_size == 0, "implied number of groups must be an integer!"
+        self.group_size = group_size
+
+        # register necessary buffers
+        self.register_buffer('weight_scales', torch.ones((self.out_features, in_features // group_size), dtype=dtype))
         self.register_buffer('weight', torch.zeros((self.out_features, self.in_features), dtype=dtype))
         if bias:
             self.register_buffer('bias', torch.zeros((self.out_features), dtype=dtype))
         else:
             self.bias = None
+        if offset:
+            self.register_buffer('offset', torch.zeros((self.out_features, in_features // group_size), dtype=dtype))
+        else:
+            self.offset = None
 
     def forward(self, x: PackedQuantizedTensor) -> torch.tensor:
+        # de-quantize the activations
         x, scales_x = x.quantized_x, x.scales_x
+        x = x * scales_x
 
-        # Perform matmul by first de-quantizing the activations and weights, and then multiplying.
-        # This is done for numerical stability. Note that in real quantization, the quantized weights and activations
-        # would be multiplied first using kernels, and then by the scales.
-        x = (x * scales_x) @ (self.weight.T * self.weight_scales.T)
+        # de-quantize the weights
+        W = dequantize(self.weight, self.weight_scales, self.offset)
 
-        if self.bias is not None:
-            x = x + self.bias
-
-        return x
+        #  run standard linear on dequantized weights and activations
+        return torch.functional.F.linear(x, W, self.bias)
 
     @classmethod
-    def like(
-        cls: type,
-        module: torch.nn.Linear,
-    ) -> 'QuarotFP16Linear':
+    def like(cls: type, module: torch.nn.Linear, groupsize: int = None, offset: bool = False) -> 'QuarotFP16Linear':
         '''
         Generate a new QuarotFP16Linear module with the same shapes & bias flag as a given Linear module.
         '''
-        return cls(module.in_features, module.out_features, bias=module.bias is not None)
+        return cls(
+            module.in_features, module.out_features, bias=module.bias is not None, group_size=groupsize, offset=offset
+        )

--- a/src/quarot/nn/quantizer.py
+++ b/src/quarot/nn/quantizer.py
@@ -9,5 +9,5 @@ class DummyActQuantizer(torch.nn.Module):
     def forward(self, x: torch.Tensor) -> PackedQuantizedTensor:
         # take all the shape of x up to last dim
         shape = x.shape[:-1] + (1,)
-        scales_x = torch.ones(shape, device=x.device)
+        scales_x = torch.ones(shape, device=x.device, dtype=x.dtype)
         return PackedQuantizedTensor(x, scales_x)

--- a/src/quarot/nn/quantizer.py
+++ b/src/quarot/nn/quantizer.py
@@ -1,6 +1,7 @@
 import torch
 
-from quarot.quant_utils import PackedQuantizedTensor
+from ..quant_utils import PackedQuantizedTensor, dequantize
+from ..rtn import calculate_scales, quantize_weight_rtn
 
 
 class DummyActQuantizer(torch.nn.Module):
@@ -11,3 +12,39 @@ class DummyActQuantizer(torch.nn.Module):
         shape = x.shape[:-1] + (1,)
         scales_x = torch.ones(shape, device=x.device, dtype=x.dtype)
         return PackedQuantizedTensor(x, scales_x)
+
+
+class ActQuantizer(torch.nn.Module):
+    '''Quantizer for activations. Applies round-to-nearest quantization tensor-wise across the seqlen and hidden_dim dimensions.'''
+
+    def __init__(self, bits: int, symmetric: bool = True, clip_ratio: float = 1.0) -> None:
+        super().__init__()
+        self.bits = bits
+        assert symmetric, "Activation quantization should be symmetric."
+        self.clip_ratio = clip_ratio
+
+    def forward(self, x: torch.Tensor) -> PackedQuantizedTensor:
+        x_scales, _ = calculate_scales(x, self.bits, symmetric=True, clip_weights=False, clip_ratio=self.clip_ratio)
+        quantized_x = quantize_weight_rtn(x, x_scales, None, self.bits)
+        return PackedQuantizedTensor(quantized_x, x_scales)
+
+
+class KVQuantizerDequantizer(torch.nn.Module):
+    '''Quantizer for quantizing and immediately dequantizing K and V. Applies round-to-nearest quantization head-wise.'''
+
+    def __init__(
+        self, bits: int, symmetric: bool = False, clip_ratio: float = 1.0, groupsize: int | None = None
+    ) -> None:
+        super().__init__()
+        self.bits = bits
+        assert not symmetric, "KV quantization should be asymmetric."
+        self.clip_ratio = clip_ratio
+        self.groupsize = groupsize
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_scales, x_offsets = calculate_scales(
+            x, self.bits, symmetric=False, clip_weights=False, clip_ratio=self.clip_ratio, groupsize=self.groupsize
+        )
+        quantized_x = quantize_weight_rtn(x, x_scales, x_offsets, self.bits)
+        dequantized_x = dequantize(quantized_x, x_scales, x_offsets)
+        return dequantized_x

--- a/src/quarot/quant_utils.py
+++ b/src/quarot/quant_utils.py
@@ -20,3 +20,22 @@ class PackedQuantizedTensor:
     @property
     def dtype(self) -> torch.dtype:
         return self.quantized_x.dtype
+
+
+def dequantize(W_ints: torch.Tensor, scale: torch.Tensor, offset: torch.Tensor | None):
+    """
+    Reconstruct the (approximate) weight tensor from the quantized weights, scales, and offsets.
+
+    Here, repeat_interleave is used apply the scale and offset accross each group.
+
+    The shape of W_ints is (out_features, in_features)
+    The shape of scale is (out_features, in_features // group_size)
+    The shape of offset is (out_features, in_features // group_size) (optional)
+    """
+    groupsize = W_ints.shape[-1] // scale.shape[-1]
+    if offset is None:
+        offset = 0
+    else:
+        offset = torch.repeat_interleave(offset, groupsize, dim=-1)
+    W = (W_ints - offset) * torch.repeat_interleave(scale, groupsize, dim=-1)
+    return W

--- a/src/quarot/rotate.py
+++ b/src/quarot/rotate.py
@@ -43,7 +43,7 @@ def rotate_model(model_adapter: ModelAdapter, seed: int = 0) -> None:
         rotate_mlp_input(layer_adapter, Q)
         rotate_mlp_output(layer_adapter, Q)
         apply_hadamard(layer_adapter.get_mlp_output())
-        apply_hadamard_headwise(layer_adapter.get_v_proj(), head_dim=head_dim)
-        apply_hadamard(layer_adapter.get_attention_output())
+        apply_hadamard_headwise(layer_adapter.get_v_proj(), head_dim)
+        apply_hadamard(layer_adapter.get_attention_output(), head_dim)
 
     utils.cleanup_memory()

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -12,6 +12,8 @@ def quantize_module_rtn(
     scales are stored in the module's weight_scales buffer, and are also stored in torch.float16.
     """
     weight = module.weight.data
+    device = weight.device
+    weight = weight.cuda()
 
     if perchannel:
         max_weight = torch.max(weight, torch.zeros_like(weight)).max(dim=1, keepdim=True).values
@@ -29,39 +31,42 @@ def quantize_module_rtn(
     if clip_weights:
         # Perform a grid search to find the best weight scales according to the error between the original weights and the
         # quantized-then-dequantized weights.
-        max_shrink = 0.8
-        n_grid = 100
+        max_shrink_factor = 0.8
+        grid_size = 100
         error_norm = 2.4
-        best_quantization_error = torch.full([weight.shape[0]], float('inf'), device=weight.device)
-        for i in range(int(max_shrink * n_grid)):
-            shrink_factor = 1 - i / n_grid
-            candidate_max_weight = shrink_factor * max_weight
 
-            if symmetric:
-                candidate_scale = candidate_max_weight / max_int
+        shrink_factors = 1 - torch.arange(int(max_shrink_factor * grid_size)) / grid_size
+        candidate_max_weights = shrink_factors.to(weight.device) * max_weight
 
-                # quantize the candidate weights
-                candidate_quantized_W = torch.clamp(torch.round(weight / candidate_scale), -max_int, max_int)
+        if symmetric:
+            candidate_scales = candidate_max_weights / max_int
+            candidate_scales = candidate_scales.unsqueeze(1)
+            weight = weight.unsqueeze(-1)
 
-                # dequantize the candidate weights
-                reconstructed_weight = candidate_quantized_W * candidate_scale
-            else:
-                raise NotImplementedError("Asymmetric quantization not implemented yet.")
+            # Quantize weights
+            candidate_quantized_weights = torch.clamp(torch.round(weight / candidate_scales), -max_int, max_int)
 
-            # calculate in-place the `error_norm`-norm error between the original and reconstructed weights
-            quantization_error = torch.sum(reconstructed_weight.sub_(weight).abs_().pow_(error_norm), 1)
+            # Dequantize weights
+            reconstructed_weights = candidate_quantized_weights * candidate_scales
+        else:
+            raise NotImplementedError("Asymmetric quantization not implemented yet.")
 
-            best_scale_indices = quantization_error < best_quantization_error
-            if torch.any(best_scale_indices):
-                best_quantization_error[best_scale_indices] = quantization_error[best_scale_indices]
-                weight_scales[best_scale_indices] = candidate_scale[best_scale_indices]
+        # Compute quantization error and find the best scale for each weight
+        quantization_errors = torch.sum(torch.abs(reconstructed_weights - weight).pow_(error_norm), 1)
+        best_scale_indices = torch.argmin(quantization_errors, dim=-1)
+        weight_scales = torch.gather(candidate_scales.squeeze(1), 1, best_scale_indices.unsqueeze(1))
 
     # Quantize the weights
+    weight = weight.squeeze(-1)
     W_quantized = torch.clamp(torch.round(weight / weight_scales), -max_int, max_int)
 
     # Set the int-quantized weights and the scales
     module.weight.data = W_quantized
     module.weight_scales = weight_scales
+
+    # Move the weights back to the original device
+    module.weight.data = module.weight.data.to(device)
+    module.weight_scales = module.weight_scales.to(device)
 
 
 def quantize_model_rtn(

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -1,0 +1,46 @@
+import torch
+
+from quarot.nn.linear import QuarotFP16Linear
+
+
+def quantize_module_rtn(module: QuarotFP16Linear, bits: int, sym: bool = True, perchannel: bool = True) -> None:
+    """
+    Quantize the weights of a QuarotFP16Linear module to INT<bits> using the Round-to-Nearest scheme, storing the weights in torch.float16. The weight
+    scales are stored in the module's weight_scales buffer, and are also stored in torch.float16.
+    """
+    W = module.weight.data
+
+    if perchannel:
+        max_weight = torch.max(W, torch.zeros_like(W)).max(dim=1, keepdim=True).values
+        min_weight = torch.min(W, torch.zeros_like(W)).min(dim=1, keepdim=True).values
+    else:
+        raise NotImplementedError("Tensor-wise quantization not implemented yet.")
+
+    if sym:
+        max_weight = torch.maximum(max_weight, -min_weight).clamp(min=1e-5)
+        max_integer_value = torch.tensor(2 ** (bits - 1) - 1, device=W.device)
+        weight_scales = max_weight / max_integer_value
+    else:
+        raise NotImplementedError("Asymmetric quantization not implemented yet.")
+
+    # Quantize the weights
+    W_quantized = torch.round(W / weight_scales).clamp(-max_integer_value, max_integer_value)
+
+    # Set the int-quantized weights and the scales
+    module.weight.data = W_quantized
+    module.weight_scales = weight_scales
+
+
+def quantize_model_rtn(model, bits: int, sym: bool = True, perchannel: bool = True) -> None:
+    """
+    Quantize the weights of a model using the Round-to-Nearest scheme.
+    """
+    layers = model.model.layers
+    for layer in layers:
+        quantize_module_rtn(layer.mlp.up_proj, bits, sym, perchannel)
+        quantize_module_rtn(layer.mlp.gate_proj, bits, sym, perchannel)
+        quantize_module_rtn(layer.mlp.down_proj, bits, sym, perchannel)
+        quantize_module_rtn(layer.self_attn.q_proj, bits, sym, perchannel)
+        quantize_module_rtn(layer.self_attn.k_proj, bits, sym, perchannel)
+        quantize_module_rtn(layer.self_attn.v_proj, bits, sym, perchannel)
+        quantize_module_rtn(layer.self_attn.o_proj, bits, sym, perchannel)

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -4,128 +4,230 @@
 import torch
 from tqdm import tqdm
 
-from quarot.nn.linear import QuarotFP16Linear
+from .nn.linear import QuarotFP16Linear
+from .quant_utils import dequantize
 
 
-def calculate_max_int(bits: int, symmetric: bool = True) -> torch.Tensor:
+def calculate_min_max_int(bits: int, symmetric: bool = True) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Calculate the maximum representable integer value given the number of bits and the quantization scheme.
     """
     if symmetric:
         max_int = torch.tensor(2 ** (bits - 1) - 1)
+        min_int = -(max_int + 1)
     else:
-        raise NotImplementedError("Asymmetric quantization not implemented yet.")
-    return max_int
+        max_int = torch.tensor(2**bits - 1)
+        min_int = torch.zeros(1)
+    return min_int, max_int
 
 
-def quantize_weight_rtn(weight: torch.Tensor, scale: torch.Tensor, bits: int, symmetric: bool = True) -> torch.Tensor:
+def calculate_min_max_weight(weight: torch.Tensor, symmetric: bool = True) -> tuple[torch.Tensor, torch.Tensor]:
     """
-    Quantize a weight tensor to INT<bits> using the given scale.
+    Calculate the minimum and maximum weights in a weight tensor.
+    If symmetric, the max weight is
+    the larger of max weight or the absolute value of min weight.
     """
-    device = weight.device
-    weight = weight.cuda()
-    scale = scale.cuda()
+    max_weight = torch.max(weight, torch.zeros_like(weight)).max(dim=-1, keepdim=True).values
+    min_weight = torch.min(weight, torch.zeros_like(weight)).min(dim=-1, keepdim=True).values
 
     if symmetric:
-        max_int = calculate_max_int(bits, symmetric).to(device=weight.device)
-        quantized_weight = torch.clamp(torch.round(weight / scale), -(max_int + 1), max_int)
-    else:
-        raise NotImplementedError("Asymmetric quantization not implemented yet.")
+        max_weight = torch.maximum(max_weight, torch.abs(min_weight)).clamp(min=1e-5)
 
-    quantized_weight = quantized_weight.to(device)
-    return quantized_weight
+    return min_weight, max_weight
 
 
 def calculate_scales(
-    weight: torch.Tensor, bits: int, symmetric: bool = True, perchannel: bool = True, clip_weights=True
-) -> torch.Tensor:
+    weight: torch.Tensor,
+    bits: int,
+    symmetric: bool,
+    clip_weights: bool = False,
+    vectorized: bool = True,
+    clip_ratio: float = 1.0,
+    groupsize: int | None = None,
+    device='cuda',
+) -> tuple[torch.Tensor, torch.Tensor | None]:
     """
-    Calculate the scales for quantizing a weight tensor to INT<bits> using the Round-to-Nearest scheme. If clip_weights is True,
-    the scales are found using a grid search to minimize the quantization error.
+    Calculate the scales (and offsets if asymmetric) for quantizing a weight tensor to INT<bits> using the Round-to-Nearest scheme.
     """
-    device = weight.device
-    weight = weight.cuda()
+    orig_device = weight.device
+    weight = weight.to(device=device)
 
-    if perchannel:
-        max_weight = torch.max(weight, torch.zeros_like(weight)).max(dim=1, keepdim=True).values
-        min_weight = torch.min(weight, torch.zeros_like(weight)).min(dim=1, keepdim=True).values
-    else:
-        raise NotImplementedError("Tensor-wise quantization not implemented yet.")
+    if groupsize:
+        # reshape the last dimension into num_groups x group_size
+        new_shape = list(weight.shape[:-1]) + [weight.shape[-1] // groupsize, groupsize]
+        weight = weight.reshape(new_shape)
 
+    min_weight, max_weight = calculate_min_max_weight(weight, symmetric=symmetric)
+    min_weight *= clip_ratio
+    max_weight *= clip_ratio
+
+    _, max_int = calculate_min_max_int(bits, symmetric=symmetric)
+    max_int = max_int.to(device=weight.device)
+
+    # Calculate scales and offsets
     if symmetric:
-        max_weight = torch.maximum(max_weight, -min_weight).clamp(min=1e-5)
-        max_int = calculate_max_int(bits, symmetric).to(device=weight.device)
-        weight_scales = max_weight / max_int
+        scale = max_weight / max_int
+        offset = None
     else:
-        raise NotImplementedError("Asymmetric quantization not implemented yet.")
+        scale = (max_weight - min_weight) / max_int
+        offset = torch.round(-min_weight / scale)
 
     if clip_weights:
         # Perform a grid search to find the best weight scales according to quantization error.
-        # TODO: This vectorized implementation gives OOM for Llama-2 70B.
         max_shrink_factor = 0.80
         n_steps = int(100 * (max_shrink_factor)) + 1
         error_norm = 2.4
+        shrink_factors = torch.linspace(1.0, 1 - max_shrink_factor, n_steps).to(weight.device)
 
-        shrink_factors = torch.linspace(1.0, 1 - max_shrink_factor, n_steps)
-        candidate_max_weights = shrink_factors.to(weight.device) * max_weight
+        if vectorized:
+            # This vectorized implementation gives OOM for Llama-2 70B.
+            candidate_max_weights = shrink_factors * max_weight
+            candidate_min_weights = shrink_factors * min_weight
 
-        if symmetric:
-            candidate_scales = candidate_max_weights / max_int
+            if symmetric:
+                candidate_scales = candidate_max_weights / max_int
+                candidate_offset = None
+            else:
+                candidate_scales = (candidate_max_weights - candidate_min_weights) / max_int
+                candidate_offset = torch.round(-candidate_min_weights / candidate_scales)
+
             candidate_scales = candidate_scales.unsqueeze(1)
+            if not symmetric:
+                candidate_offset = candidate_offset.unsqueeze(1)
+
             weight = weight.unsqueeze(-1)
 
             # Quantize weights
-            candidate_quantized_weights = quantize_weight_rtn(weight, candidate_scales, bits, symmetric)
+            candidate_quantized_weights = quantize_weight_rtn(weight, candidate_scales, candidate_offset, bits)
 
             # Dequantize weights
-            reconstructed_weights = candidate_quantized_weights * candidate_scales
+            if symmetric:
+                reconstructed_weights = candidate_quantized_weights * candidate_scales
+            else:
+                reconstructed_weights = (candidate_quantized_weights - offset) * candidate_scales
+
+            # Compute quantization error and find the best scale (and offset if asymmetric) for each weight
+            quantization_errors = torch.sum(torch.abs(reconstructed_weights - weight).pow_(error_norm), 1)
+            best_idx = torch.argmin(quantization_errors, dim=-1)
+            scale = torch.gather(candidate_scales.squeeze(1), 1, best_idx.unsqueeze(1))
+            if not symmetric:
+                offset = torch.gather(candidate_offset.squeeze(1), 1, best_idx.unsqueeze(1))
+
         else:
-            raise NotImplementedError("Asymmetric quantization not implemented yet.")
+            best_quantization_error = torch.full(
+                (weight.shape[0],), float("inf"), device=weight.device, dtype=weight.dtype
+            )
+            for i in range(n_steps):
+                shrink_factor = shrink_factors[i]
+                candidate_max_weight = shrink_factor * max_weight
+                candidate_min_weight = shrink_factor * min_weight
 
-        # Compute quantization error and find the best scale for each weight
-        quantization_errors = torch.sum(torch.abs(reconstructed_weights - weight).pow_(error_norm), 1)
-        best_scale_indices = torch.argmin(quantization_errors, dim=-1)
-        weight_scales = torch.gather(candidate_scales.squeeze(1), 1, best_scale_indices.unsqueeze(1))
+                if symmetric:
+                    candidate_scale = candidate_max_weight / max_int
+                    candidate_offset = None
+                else:
+                    candidate_scale = (candidate_max_weight - candidate_min_weight) / max_int
+                    candidate_offset = torch.round(-candidate_min_weight / candidate_scale)
 
-    weight = weight.to(device)
-    weight_scales = weight_scales.to(device)
-    return weight_scales
+                # Quantize weights
+                candidate_quantized_weight = quantize_weight_rtn(weight, candidate_scale, candidate_offset, bits)
+
+                # Dequantize weights
+                if symmetric:
+                    reconstructed_weight = candidate_quantized_weight * candidate_scale
+                else:
+                    reconstructed_weight = (candidate_quantized_weight - candidate_offset) * candidate_scale
+
+                # Compute quantization error and find the best scale (and offset if asymmetric)
+                quantization_error = torch.sum(torch.abs(reconstructed_weight - weight).pow_(error_norm), 1)
+                if i == 0 or torch.any(quantization_error < best_quantization_error):
+                    improved_idx = torch.where(quantization_error < best_quantization_error)
+                    scale[improved_idx] = candidate_scale[improved_idx]
+                    if not symmetric:
+                        offset[improved_idx] = candidate_offset[improved_idx]
+
+                    best_quantization_error[improved_idx] = quantization_error[improved_idx]
+
+    if groupsize:
+        scale = scale.squeeze(-1)
+        if offset is not None:
+            offset = offset.squeeze(-1)
+
+    weight = weight.to(orig_device)
+    scale = scale.to(orig_device)
+    offset = offset.to(orig_device) if offset is not None else None
+
+    return scale, offset
+
+
+def quantize_weight_rtn(weight: torch.Tensor, scale: torch.Tensor, offset: torch.Tensor | None, bits: int):
+    """
+    Quantize a weight tensor to INT<bits> using the given scale and offset.
+    """
+    scale = torch.repeat_interleave(scale, weight.shape[1] // scale.shape[1], dim=1)
+
+    if offset is None:
+        _offset = 0
+    else:
+        _offset = torch.repeat_interleave(offset, weight.shape[1] // offset.shape[1], dim=1)
+
+    min_int, max_int = calculate_min_max_int(bits, symmetric=offset is None)
+    min_int = min_int.to(weight.device, weight.dtype)
+    max_int = max_int.to(weight.device, weight.dtype)
+    weight_ints = torch.round(weight / scale) + _offset
+
+    quantized_weight = torch.clamp(weight_ints, min_int, max_int)
+    return quantized_weight
 
 
 def quantize_module_rtn(
-    module: QuarotFP16Linear, bits: int, symmetric: bool = True, perchannel: bool = True, clip_weights: bool = True
+    module: QuarotFP16Linear,
+    bits: int,
+    symmetric: bool = True,
+    clip_weights: bool = True,
+    vectorized: bool = True,
+    groupsize: int | None = None,
 ) -> None:
     """
     Quantize the weights of a QuarotFP16Linear module to INT<bits> using the Round-to-Nearest scheme, storing the weights in torch.float16. The weight
     scales are stored in the module's weight_scales buffer, and are also stored in torch.float16.
     """
     weight = module.weight
-    weight_scales = calculate_scales(weight, bits, symmetric, perchannel, clip_weights)
-    quantized_weight = quantize_weight_rtn(weight, weight_scales, bits, symmetric)
 
-    module.weight.data = quantized_weight
-    module.weight_scales = weight_scales
+    scale, offset = calculate_scales(weight, bits, symmetric, clip_weights, vectorized=vectorized, groupsize=groupsize)
+    quantized_weight = quantize_weight_rtn(weight, scale, offset, bits)
+
+    if isinstance(module, QuarotFP16Linear):
+        module.weight.data = quantized_weight
+        module.weight_scales.data = scale
+        if not symmetric:
+            module.offset.data = offset
+    elif isinstance(module, torch.nn.Linear):
+        module.weight.data = dequantize(quantized_weight, scale, offset)
+    else:
+        raise NotImplementedError
 
 
 def quantize_model_rtn(
-    model, bits: int, symmetric: bool = True, perchannel: bool = True, clip_weights: bool = True
+    model,
+    bits: int,
+    symmetric: bool = True,
+    clip_weights: bool = True,
+    vectorized: bool = True,
+    groupsize: int | None = None,
 ) -> None:
     """
-    Quantize the weights of a model using the Round-to-Nearest scheme.
+    Quantize the weights (in QuarotFP16Linear modules) of a QuaRot model using the Round-to-Nearest scheme.
 
     Args:
         model: the model to quantize
         bits: the number of bits to quantize the weights to
         symmetric: whether to use symmetric quantization
-        perchannel: whether to use per-channel quantization
-        clip_weights: whether to clip the weights to the maximum representable value
+        clip_weights: whether to perform a search for the best clip ratio for weight clipping
+        vectorized: whether to use a vectorized implementation for weight clipping
+        groupsize: the groupsize for quantization. If None, quantize each channel in full.
     """
-    layers = model.model.layers
-    for layer in tqdm(layers, desc="Quantizing layers", unit="layer"):
-        quantize_module_rtn(layer.mlp.up_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.mlp.gate_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.mlp.down_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.self_attn.q_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.self_attn.k_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.self_attn.v_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.self_attn.o_proj, bits, symmetric, perchannel, clip_weights)
+    for layer in tqdm(model.model.layers, unit="layer", desc="Quantizing layer"):
+        for _, module in layer.named_modules():
+            if isinstance(module, QuarotFP16Linear):
+                quantize_module_rtn(module, bits, symmetric, clip_weights, vectorized, groupsize)

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -44,7 +44,7 @@ def quantize_module_rtn(
             weight = weight.unsqueeze(-1)
 
             # Quantize weights
-            candidate_quantized_weights = torch.clamp(torch.round(weight / candidate_scales), -max_int, max_int)
+            candidate_quantized_weights = torch.clamp(torch.round(weight / candidate_scales), -(max_int+1), max_int)
 
             # Dequantize weights
             reconstructed_weights = candidate_quantized_weights * candidate_scales
@@ -57,8 +57,11 @@ def quantize_module_rtn(
         weight_scales = torch.gather(candidate_scales.squeeze(1), 1, best_scale_indices.unsqueeze(1))
 
     # Quantize the weights
-    weight = weight.squeeze(-1)
-    W_quantized = torch.clamp(torch.round(weight / weight_scales), -max_int, max_int)
+    if symmetric:
+        weight = weight.squeeze(-1)
+        W_quantized = torch.clamp(torch.round(weight / weight_scales), -(max_int+1), max_int)
+    else:
+        raise NotImplementedError("Asymmetric quantization not implemented yet.")
 
     # Set the int-quantized weights and the scales
     module.weight.data = W_quantized

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -44,7 +44,7 @@ def quantize_module_rtn(
             weight = weight.unsqueeze(-1)
 
             # Quantize weights
-            candidate_quantized_weights = torch.clamp(torch.round(weight / candidate_scales), -(max_int+1), max_int)
+            candidate_quantized_weights = torch.clamp(torch.round(weight / candidate_scales), -(max_int + 1), max_int)
 
             # Dequantize weights
             reconstructed_weights = candidate_quantized_weights * candidate_scales
@@ -59,7 +59,7 @@ def quantize_module_rtn(
     # Quantize the weights
     if symmetric:
         weight = weight.squeeze(-1)
-        W_quantized = torch.clamp(torch.round(weight / weight_scales), -(max_int+1), max_int)
+        W_quantized = torch.clamp(torch.round(weight / weight_scales), -(max_int + 1), max_int)
     else:
         raise NotImplementedError("Asymmetric quantization not implemented yet.")
 

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -1,46 +1,88 @@
 import torch
+from tqdm import tqdm
 
 from quarot.nn.linear import QuarotFP16Linear
 
 
-def quantize_module_rtn(module: QuarotFP16Linear, bits: int, sym: bool = True, perchannel: bool = True) -> None:
+def quantize_module_rtn(
+    module: QuarotFP16Linear, bits: int, symmetric: bool = True, perchannel: bool = True, clip_weights=True
+) -> None:
     """
     Quantize the weights of a QuarotFP16Linear module to INT<bits> using the Round-to-Nearest scheme, storing the weights in torch.float16. The weight
     scales are stored in the module's weight_scales buffer, and are also stored in torch.float16.
     """
-    W = module.weight.data
+    weight = module.weight.data
 
     if perchannel:
-        max_weight = torch.max(W, torch.zeros_like(W)).max(dim=1, keepdim=True).values
-        min_weight = torch.min(W, torch.zeros_like(W)).min(dim=1, keepdim=True).values
+        max_weight = torch.max(weight, torch.zeros_like(weight)).max(dim=1, keepdim=True).values
+        min_weight = torch.min(weight, torch.zeros_like(weight)).min(dim=1, keepdim=True).values
     else:
         raise NotImplementedError("Tensor-wise quantization not implemented yet.")
 
-    if sym:
+    if symmetric:
         max_weight = torch.maximum(max_weight, -min_weight).clamp(min=1e-5)
-        max_integer_value = torch.tensor(2 ** (bits - 1) - 1, device=W.device)
-        weight_scales = max_weight / max_integer_value
+        max_int = torch.tensor(2 ** (bits - 1) - 1, device=weight.device)
+        weight_scales = max_weight / max_int
     else:
         raise NotImplementedError("Asymmetric quantization not implemented yet.")
 
+    if clip_weights:
+        # Perform a grid search to find the best weight scales according to the error between the original weights and the
+        # quantized-then-dequantized weights.
+        max_shrink = 0.8
+        n_grid = 100
+        error_norm = 2.4
+        best_quantization_error = torch.full([weight.shape[0]], float('inf'), device=weight.device)
+        for i in range(int(max_shrink * n_grid)):
+            shrink_factor = 1 - i / n_grid
+            candidate_max_weight = shrink_factor * max_weight
+
+            if symmetric:
+                candidate_scale = candidate_max_weight / max_int
+
+                # quantize the candidate weights
+                candidate_quantized_W = torch.clamp(torch.round(weight / candidate_scale), -max_int, max_int)
+
+                # dequantize the candidate weights
+                reconstructed_weight = candidate_quantized_W * candidate_scale
+            else:
+                raise NotImplementedError("Asymmetric quantization not implemented yet.")
+
+            # calculate in-place the `error_norm`-norm error between the original and reconstructed weights
+            quantization_error = torch.sum(reconstructed_weight.sub_(weight).abs_().pow_(error_norm), 1)
+
+            best_scale_indices = quantization_error < best_quantization_error
+            if torch.any(best_scale_indices):
+                best_quantization_error[best_scale_indices] = quantization_error[best_scale_indices]
+                weight_scales[best_scale_indices] = candidate_scale[best_scale_indices]
+
     # Quantize the weights
-    W_quantized = torch.round(W / weight_scales).clamp(-max_integer_value, max_integer_value)
+    W_quantized = torch.clamp(torch.round(weight / weight_scales), -max_int, max_int)
 
     # Set the int-quantized weights and the scales
     module.weight.data = W_quantized
     module.weight_scales = weight_scales
 
 
-def quantize_model_rtn(model, bits: int, sym: bool = True, perchannel: bool = True) -> None:
+def quantize_model_rtn(
+    model, bits: int, symmetric: bool = True, perchannel: bool = True, clip_weights: bool = True
+) -> None:
     """
     Quantize the weights of a model using the Round-to-Nearest scheme.
+
+    Args:
+        model: the model to quantize
+        bits: the number of bits to quantize the weights to
+        symmetric: whether to use symmetric quantization
+        perchannel: whether to use per-channel quantization
+        clip_weights: whether to clip the weights to the maximum representable value
     """
     layers = model.model.layers
-    for layer in layers:
-        quantize_module_rtn(layer.mlp.up_proj, bits, sym, perchannel)
-        quantize_module_rtn(layer.mlp.gate_proj, bits, sym, perchannel)
-        quantize_module_rtn(layer.mlp.down_proj, bits, sym, perchannel)
-        quantize_module_rtn(layer.self_attn.q_proj, bits, sym, perchannel)
-        quantize_module_rtn(layer.self_attn.k_proj, bits, sym, perchannel)
-        quantize_module_rtn(layer.self_attn.v_proj, bits, sym, perchannel)
-        quantize_module_rtn(layer.self_attn.o_proj, bits, sym, perchannel)
+    for layer in tqdm(layers, desc="Quantizing layers", unit="layer"):
+        quantize_module_rtn(layer.mlp.up_proj, bits, symmetric, perchannel, clip_weights)
+        quantize_module_rtn(layer.mlp.gate_proj, bits, symmetric, perchannel, clip_weights)
+        quantize_module_rtn(layer.mlp.down_proj, bits, symmetric, perchannel, clip_weights)
+        quantize_module_rtn(layer.self_attn.q_proj, bits, symmetric, perchannel, clip_weights)
+        quantize_module_rtn(layer.self_attn.k_proj, bits, symmetric, perchannel, clip_weights)
+        quantize_module_rtn(layer.self_attn.v_proj, bits, symmetric, perchannel, clip_weights)
+        quantize_module_rtn(layer.self_attn.o_proj, bits, symmetric, perchannel, clip_weights)

--- a/test.sh
+++ b/test.sh
@@ -8,4 +8,4 @@ set -e
 pre-commit run --all-files --hook-stage manual --verbose
 
 # Run tests
-python3 -m pytest -m "not (gpu or experiment)"
+python3 -m pytest -m "not (gpu or experiment or quarot or quarot_experiment)"

--- a/tests/test_gptq.py
+++ b/tests/test_gptq.py
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pytest
+import torch
+
+
+@pytest.mark.quarot
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "weight",
+    [torch.tensor([[1.1, -2.3, 3.5], [-1.5, 2.6, -7.0]])],
+)
+@pytest.mark.parametrize("bits", [3, 4, 8])
+@pytest.mark.parametrize("symmetric", [True, False])
+def test_gptq_eye_hessian(weight, bits, symmetric):
+
+    # imports which require a GPU build machine
+    from quarot.gptq import quantize_weight_gptq
+    from quarot.rtn import calculate_scales, quantize_weight_rtn
+
+    hessian = torch.eye(weight.shape[1], dtype=torch.float32)
+
+    gptq_quantized_weight, gptq_scale, gptq_offset = quantize_weight_gptq(
+        weight, hessian, bits, symmetric=symmetric, clip_weights=False
+    )
+
+    rtn_scale, rtn_offset = calculate_scales(weight, bits, symmetric=symmetric, clip_weights=False)
+    rtn_quantized_weight = quantize_weight_rtn(weight, rtn_scale, rtn_offset, bits)
+
+    assert torch.allclose(gptq_quantized_weight, rtn_quantized_weight)
+    assert torch.allclose(gptq_scale, rtn_scale)
+    if symmetric:
+        assert gptq_offset is None
+        assert rtn_offset is None
+    else:
+        assert torch.allclose(gptq_offset, rtn_offset)

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -4,22 +4,43 @@
 import pytest
 import torch
 
-from quarot.nn.quantizer import DummyActQuantizer
-
 
 @pytest.mark.quarot
 def test_dummy_quantizer():
-    """Sanity checks for emulated quantization."""
+    from quarot.nn.quantizer import DummyActQuantizer
 
     quantizer = DummyActQuantizer()
 
-    x = torch.tensor([1.02, 0.056, -3.2, 4.999, 5.0])
+    act = torch.tensor([1.02, 0.056, -3.2, 4.999, 5.0])
 
-    packed_tensor = quantizer(x)
+    packed_quantized_act = quantizer(act)
+    quantized_x, scales_x = packed_quantized_act.quantized_x, packed_quantized_act.scales_x
 
-    quantized_x = packed_tensor.quantized_x
-    scales_x = packed_tensor.scales_x
-
+    # Check scales are ones and quantization error is nil
     dequantized_x = quantized_x * scales_x
+    assert torch.allclose(scales_x, torch.ones_like(scales_x))
+    assert torch.allclose(act, dequantized_x)
 
-    assert torch.allclose(dequantized_x, x, atol=1e-3, rtol=1e-3)
+
+@pytest.mark.quarot
+@pytest.mark.gpu
+def test_act_quantizer():
+    from quarot.nn.quantizer import ActQuantizer
+
+    quantizer = ActQuantizer(bits=8)
+
+    batch_size = 2
+    seq_len = 4
+    hidden_dim = 8
+    act = torch.randn(batch_size, seq_len, hidden_dim)
+
+    packed_quantized_act = quantizer(act)
+    quantized_act, act_scales = packed_quantized_act.quantized_x, packed_quantized_act.scales_x
+
+    # Check shapes
+    assert quantized_act.shape == (batch_size, seq_len, hidden_dim)
+    assert act_scales.shape == (batch_size, seq_len, 1)
+
+    # Check quantization error (NB: flakey, depends on randomness of act)
+    dequantized_act = quantized_act * act_scales
+    assert torch.allclose(act, dequantized_act, rtol=1e-2, atol=1e-2)

--- a/tests/test_rtn.py
+++ b/tests/test_rtn.py
@@ -15,6 +15,7 @@ from quarot.rtn import calculate_scales, quantize_weight_rtn
         (3, torch.tensor([[-1.0, 1.0, 2.0, 3.0], [-0.5, 1.0, 2.0, -3.0]]), torch.tensor([[1.0], [1.0]])),
         (3, torch.tensor([[-1.0, 1.0, 1.0, 1.5], [-0.5, 1.0, 1.0, -1.5]]), torch.tensor([[0.5], [0.5]])),
         (4, torch.tensor([[-1.0, 1.0, 2.0, 3.5], [-0.5, 1.0, 2.0, -7.0]]), torch.tensor([[0.5], [1.0]])),
+        (8, torch.tensor([[-1.0, 1.0, 2.0, 31.75], [-0.5, 1.0, 2.0, -63.5], [-0.5, 1.0, 2.0, -127.0]]), torch.tensor([[0.25], [0.5], [1.0]])),
     ],
 )
 def test_calculate_scales(bits, weight, expected_scales):
@@ -29,6 +30,7 @@ def test_calculate_scales(bits, weight, expected_scales):
     [
         (3, torch.tensor([[1.1, -2.3, 3.4], [-1.5, 2.6, -2.9]]), torch.tensor([[1.0, -2.0, 3.0], [-2.0, 3.0, -3.0]])),
         (4, torch.tensor([[1.1, -2.3, 3.5], [-1.5, 2.6, -7.0]]), torch.tensor([[2.0, -5.0, 7.0], [-2.0, 3.0, -7.0]])),
+        (8, torch.tensor([[1.1, -2.3, 31.75], [-1.5, 2.6, -63.5], [-1.5, 2.6, -127.0]]), torch.tensor([[4.0, -9.0, 127.0], [-3.0, 5.0, -127.0], [-2.0, 3.0, -127.0]])),
     ],
 )
 def test_quantize_weight_rtn(bits, weight, expected_quantized_weight):

--- a/tests/test_rtn.py
+++ b/tests/test_rtn.py
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pytest
+import torch
+
+from quarot.rtn import calculate_scales, quantize_weight_rtn
+
+
+@pytest.mark.quarot
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "bits, weight, expected_scales",
+    [
+        (3, torch.tensor([[-1.0, 1.0, 2.0, 3.0], [-0.5, 1.0, 2.0, -3.0]]), torch.tensor([[1.0], [1.0]])),
+        (3, torch.tensor([[-1.0, 1.0, 1.0, 1.5], [-0.5, 1.0, 1.0, -1.5]]), torch.tensor([[0.5], [0.5]])),
+        (4, torch.tensor([[-1.0, 1.0, 2.0, 3.5], [-0.5, 1.0, 2.0, -7.0]]), torch.tensor([[0.5], [1.0]])),
+    ],
+)
+def test_calculate_scales(bits, weight, expected_scales):
+    scales = calculate_scales(weight, bits, symmetric=True, perchannel=True, clip_weights=False)
+    assert torch.allclose(scales, expected_scales)
+
+
+@pytest.mark.quarot
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "bits, weight, expected_quantized_weight",
+    [
+        (3, torch.tensor([[1.1, -2.3, 3.4], [-1.5, 2.6, -2.9]]), torch.tensor([[1.0, -2.0, 3.0], [-2.0, 3.0, -3.0]])),
+        (4, torch.tensor([[1.1, -2.3, 3.5], [-1.5, 2.6, -7.0]]), torch.tensor([[2.0, -5.0, 7.0], [-2.0, 3.0, -7.0]])),
+    ],
+)
+def test_quantize_weight_rtn(bits, weight, expected_quantized_weight):
+    scale = calculate_scales(weight, bits, symmetric=True, perchannel=True, clip_weights=False)
+    quantized_weight = quantize_weight_rtn(weight, scale, bits, symmetric=True)
+    assert torch.allclose(quantized_weight, expected_quantized_weight)

--- a/tests/test_rtn.py
+++ b/tests/test_rtn.py
@@ -15,7 +15,11 @@ from quarot.rtn import calculate_scales, quantize_weight_rtn
         (3, torch.tensor([[-1.0, 1.0, 2.0, 3.0], [-0.5, 1.0, 2.0, -3.0]]), torch.tensor([[1.0], [1.0]])),
         (3, torch.tensor([[-1.0, 1.0, 1.0, 1.5], [-0.5, 1.0, 1.0, -1.5]]), torch.tensor([[0.5], [0.5]])),
         (4, torch.tensor([[-1.0, 1.0, 2.0, 3.5], [-0.5, 1.0, 2.0, -7.0]]), torch.tensor([[0.5], [1.0]])),
-        (8, torch.tensor([[-1.0, 1.0, 2.0, 31.75], [-0.5, 1.0, 2.0, -63.5], [-0.5, 1.0, 2.0, -127.0]]), torch.tensor([[0.25], [0.5], [1.0]])),
+        (
+            8,
+            torch.tensor([[-1.0, 1.0, 2.0, 31.75], [-0.5, 1.0, 2.0, -63.5], [-0.5, 1.0, 2.0, -127.0]]),
+            torch.tensor([[0.25], [0.5], [1.0]]),
+        ),
     ],
 )
 def test_calculate_scales(bits, weight, expected_scales):
@@ -30,7 +34,11 @@ def test_calculate_scales(bits, weight, expected_scales):
     [
         (3, torch.tensor([[1.1, -2.3, 3.4], [-1.5, 2.6, -2.9]]), torch.tensor([[1.0, -2.0, 3.0], [-2.0, 3.0, -3.0]])),
         (4, torch.tensor([[1.1, -2.3, 3.5], [-1.5, 2.6, -7.0]]), torch.tensor([[2.0, -5.0, 7.0], [-2.0, 3.0, -7.0]])),
-        (8, torch.tensor([[1.1, -2.3, 31.75], [-1.5, 2.6, -63.5], [-1.5, 2.6, -127.0]]), torch.tensor([[4.0, -9.0, 127.0], [-3.0, 5.0, -127.0], [-2.0, 3.0, -127.0]])),
+        (
+            8,
+            torch.tensor([[1.1, -2.3, 31.75], [-1.5, 2.6, -63.5], [-1.5, 2.6, -127.0]]),
+            torch.tensor([[4.0, -9.0, 127.0], [-3.0, 5.0, -127.0], [-2.0, 3.0, -127.0]]),
+        ),
     ],
 )
 def test_quantize_weight_rtn(bits, weight, expected_quantized_weight):


### PR DESCRIPTION
Tested PPL for A16W4 with and without rotation:

Llama-2 7B 
- with rotation: 7.17 vs 6.76 in paper
- without rotation: 8.65 vs 6.99 in paper

Llama-2 13B 
- with rotation: 5.63 vs 5.48 in paper
- without rotation: 21.26 vs 6.32 in paper [very anomalous, should at least be better than 7B result]

Key code differences to `fake_quant`: gpu implementation of grid search for weight clipping -> halves time for applying weight RTN in 7 (30s) and 13B (1min) models compared to spcl `fake_quant`, however untested on 70B and may cause GPU OOM. The previous commit has the equivalent `fake_quant` more memory efficient method. However, what is very strange is that this takes 10mins on 7B whereas this takes only 1min in `spcl` repo.

@sashkboos could you have a look at e.g. this PR/branch at the "add weight clipping" commit and see if you can spot anything in the rtn logic that could be causing these accuracy differences? The other possibility is that there is a bug in the "no rotation" logic, and that we're actually doing things to the network that we're not meant to be doing, causing big diffs here.