### PR TITLE
Add Phi-3-mini adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Notes:
 
 The following models from Hugging Face hub are currently supported
 - [microsoft/phi-2](https://huggingface.co/microsoft/phi-2)
+- [microsoft/Phi-3-mini-4k-instruct](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct)
 - [meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b)
 - [meta-llama/Llama-2-13b-hf](https://huggingface.co/meta-llama/Llama-2-13b)
 - [meta-llama/Llama-2-70b-hf](https://huggingface.co/meta-llama/Llama-2-70b)

--- a/experiments/bo_options.py
+++ b/experiments/bo_options.py
@@ -81,5 +81,33 @@ def lora_target_map(model: str):
                     'lm_head',
                 ],
             }
+        case 'microsoft/Phi-3-mini-4k-instruct':
+            return {
+                'qkv_proj': ['qkv_proj'],
+                'attn_head': ['qkv_proj', 'o_proj'],
+                'attn_head_and_mlp': [
+                    'qkv_proj',
+                    'o_proj',
+                    'gate_up_proj',
+                    'down_proj',
+                ],
+                'attn_head_and_mlp_with_Q': [
+                    'qkv_proj',
+                    'o_proj',
+                    'attn_shortcut_Q',
+                    'gate_up_proj',
+                    'down_proj',
+                    'mlp_shortcut_Q',
+                ],
+                'attn_head_mlp_lm_head_with_Q': [
+                    'qkv_proj',
+                    'o_proj',
+                    'attn_shortcut_Q',
+                    'gate_up_proj',
+                    'down_proj',
+                    'mlp_shortcut_Q',
+                    'lm_head',
+                ],
+            }
         case _:
             raise RuntimeError(f'Lora target map undefined for model={model}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "numpy",
     "torch",
     "tqdm",
-    "transformers==4.40.1",
+    "transformers @ git+https://github.com/huggingface/transformers.git@1c52cb7",
 ]
 
 [project.optional-dependencies]
@@ -45,7 +45,7 @@ experiment = [
 
 finetune = [
     "syne-tune[gpsearchers]==0.10.0",
-    "peft==0.6.0",
+    "peft==0.6.2",
 ]
 
 all = ["transformercompression[dev,experiment,finetune]"]

--- a/src/slicegpt/__init__.py
+++ b/src/slicegpt/__init__.py
@@ -4,6 +4,7 @@
 from .adapters.llama_adapter import LlamaModelAdapter
 from .adapters.opt_adapter import OPTModelAdapter
 from .adapters.phi2_adapter import Phi2ModelAdapter
+from .adapters.phi3_adapter import Phi3ModelAdapter
 from .data_utils import get_dataset, prepare_dataloader
 from .gpu_utils import benchmark, distribute_model, evaluate_ppl
 from .hf_utils import get_model_and_tokenizer, load_sliced_model

--- a/src/slicegpt/adapters/llama_adapter.py
+++ b/src/slicegpt/adapters/llama_adapter.py
@@ -5,7 +5,6 @@
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py
 # Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
 # https://www.apache.org/licenses/LICENSE-2.0
-from typing import cast
 
 import torch
 from torch import FloatTensor, LongTensor, Tensor, matmul
@@ -186,9 +185,7 @@ class LlamaModelAdapter(ModelAdapter):
         return self.model(input_ids=input_ids).logits
 
     def convert_layer_to_compressed(self, layer: Module, layer_idx: int | None) -> Module:
-        compressed_layer = self.compressed_layer_type(cast(self.config_type, self.config), layer_idx).to(
-            self.config.torch_dtype
-        )
+        compressed_layer = self.compressed_layer_type(self.config, layer_idx).to(self.config.torch_dtype)
         compressed_layer.load_state_dict(layer.state_dict(), strict=True)
         return compressed_layer
 
@@ -204,7 +201,7 @@ class LlamaModelAdapter(ModelAdapter):
     def get_embeddings(self) -> list[Module]:
         return [self.model.model.embed_tokens]
 
-    def get_pre_head_layernorm(self) -> type:
+    def get_pre_head_layernorm(self) -> Module:
         pre_head_layernorm = self.model.model.norm
         assert isinstance(pre_head_layernorm, self.original_layer_norm_type)
         return pre_head_layernorm

--- a/src/slicegpt/adapters/opt_adapter.py
+++ b/src/slicegpt/adapters/opt_adapter.py
@@ -4,7 +4,6 @@
 # This file contains derivations from
 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/opt/modeling_opt.py
 # Copyright 2022 The Fairseq Authors and The HuggingFace Inc. team. All rights reserved.
-from typing import cast
 
 import torch
 from torch import FloatTensor, Tensor, matmul
@@ -209,7 +208,7 @@ class OPTModelAdapter(ModelAdapter):
         return self.model(input_ids=input_ids).logits
 
     def convert_layer_to_compressed(self, layer: Module, layer_idx: int | None) -> Module:
-        compressed_layer = self.compressed_layer_type(cast(self.config_type, self.config)).to(self.config.torch_dtype)
+        compressed_layer = self.compressed_layer_type(self.config).to(self.config.torch_dtype)
         compressed_layer.load_state_dict(layer.state_dict(), strict=True)
         return compressed_layer
 
@@ -225,7 +224,7 @@ class OPTModelAdapter(ModelAdapter):
     def get_embeddings(self) -> list[Module]:
         return [self.model.model.decoder.embed_tokens, self.model.model.decoder.embed_positions]
 
-    def get_pre_head_layernorm(self) -> type:
+    def get_pre_head_layernorm(self) -> Module:
         pre_head_layernorm = self.model.model.decoder.final_layer_norm
         assert pre_head_layernorm is not None
         return pre_head_layernorm

--- a/src/slicegpt/adapters/phi2_adapter.py
+++ b/src/slicegpt/adapters/phi2_adapter.py
@@ -7,8 +7,6 @@
 #
 # License updated to MIT license since 7e10f3e in https://huggingface.co/microsoft/phi-2/blob/main/LICENSE
 
-from typing import cast
-
 import torch
 from torch import FloatTensor, LongTensor, Tensor, matmul
 from torch.nn import LayerNorm, Linear, Module
@@ -183,9 +181,7 @@ class Phi2ModelAdapter(ModelAdapter):
         return self.model(input_ids=input_ids).logits
 
     def convert_layer_to_compressed(self, layer: Module, layer_idx: int | None) -> Module:
-        compressed_layer = self.compressed_layer_type(cast(self.config_type, self.config), layer_idx).to(
-            self.config.torch_dtype
-        )
+        compressed_layer = self.compressed_layer_type(self.config, layer_idx).to(self.config.torch_dtype)
         compressed_layer.load_state_dict(layer.state_dict(), strict=True)
         return compressed_layer
 
@@ -201,7 +197,7 @@ class Phi2ModelAdapter(ModelAdapter):
     def get_embeddings(self) -> list[Module]:
         return [self.model.model.embed_tokens]
 
-    def get_pre_head_layernorm(self) -> type:
+    def get_pre_head_layernorm(self) -> Module:
         pre_head_layernorm = self.model.model.final_layernorm
         assert pre_head_layernorm is not None
         return pre_head_layernorm

--- a/src/slicegpt/adapters/phi3_adapter.py
+++ b/src/slicegpt/adapters/phi3_adapter.py
@@ -1,0 +1,276 @@
+# coding=utf-8
+# Copyright 2024 Microsoft and the HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import warnings
+from typing import Any, Optional, Tuple, cast
+
+import torch
+from torch import FloatTensor, LongTensor, Tensor, matmul
+from torch.nn import Linear, Module
+from transformers import PretrainedConfig, PreTrainedTokenizerBase
+from transformers.models.phi3.modeling_phi3 import Phi3Config, Phi3DecoderLayer, Phi3ForCausalLM, Phi3RMSNorm
+
+from slicegpt.model_adapter import LayerAdapter, ModelAdapter
+
+
+class CompressedPhi3DecoderLayer(Phi3DecoderLayer):
+    """
+    This class simulates the Phi3DecoderLayer class from transformers
+    (https://github.com/huggingface/transformers/blob/main/src/transformers/models/phi3/modeling_phi3.py#L817)
+    but with the addition of a shortcut_Q attribute. This attribute is used to rotate the residual tensors.
+    """
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+        output_attentions: Optional[bool] = False,
+        use_cache: Optional[bool] = False,
+        **kwargs,
+    ) -> Tuple[Any]:
+        if "padding_mask" in kwargs:
+            warnings.warn(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. "
+                "Please make sure use `attention_mask` instead.`"
+            )
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`):
+                input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.FloatTensor`, *optional*): attention mask of size
+                `(batch, 1, tgt_len, src_len)` where padding elements are indicated by very large negative values.
+            position_ids (`torch.LongTensor` of shape `({0})`, *optional*):
+                Indices of positions of each input sequence tokens in the position embeddings. Selected in the range
+                `[0, config.n_positions - 1]`. [What are position IDs?](../glossary#position-ids)
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+            use_cache (`bool`, *optional*):
+                If set to `True`, `past_key_values` key value states are returned and can be used to speed up decoding
+                (see `past_key_values`).
+            past_key_value (`Tuple(torch.FloatTensor)`, *optional*): cached past key and value projection states
+        """
+
+        residual = hidden_states
+
+        hidden_states = self.input_layernorm(hidden_states)
+
+        # Self Attention
+        attn_outputs, self_attn_weights, present_key_value = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+        )
+
+        if self.attn_shortcut_Q is not None:
+            rotated_residual = matmul(residual, self.attn_shortcut_Q)
+            hidden_states = rotated_residual + self.resid_attn_dropout(attn_outputs)
+        else:
+            hidden_states = residual + self.resid_attn_dropout(attn_outputs)
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+
+        if self.mlp_shortcut_Q is not None:
+            rotated_residual = matmul(residual, self.mlp_shortcut_Q)
+            hidden_states = rotated_residual + self.resid_mlp_dropout(hidden_states)
+        else:
+            hidden_states = residual + self.resid_mlp_dropout(hidden_states)
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (self_attn_weights,)
+
+        if use_cache:
+            outputs += (present_key_value,)
+
+        return outputs
+
+
+class Phi3LayerAdapter(LayerAdapter):
+    def __init__(self, layer: Phi3DecoderLayer) -> None:
+        super().__init__()
+        self._layer: Phi3DecoderLayer = layer
+
+    @property
+    def layer(self) -> Module:
+        return self._layer
+
+    @property
+    def hidden_states_args_position(self) -> int:
+        return 0
+
+    @property
+    def hidden_states_output_position(self) -> int:
+        return 0
+
+    def get_first_layernorm(self) -> Module:
+        return self.layer.input_layernorm
+
+    def get_second_layernorm(self) -> Module:
+        return self.layer.post_attention_layernorm
+
+    def get_attention_inputs(self) -> list[Linear]:
+        return [self.layer.self_attn.qkv_proj]
+
+    def get_attention_output(self) -> Linear:
+        return self.layer.self_attn.o_proj
+
+    def get_mlp_inputs(self) -> list[Linear]:
+        return [self.layer.mlp.gate_up_proj]
+
+    def get_mlp_output(self) -> Linear:
+        return self.layer.mlp.down_proj
+
+
+class Phi3ModelAdapter(ModelAdapter):
+    def __init__(self, model: Phi3ForCausalLM) -> None:
+        super().__init__()
+        self._model: Phi3ForCausalLM = model
+
+    @property
+    def model(self) -> Module:
+        return self._model
+
+    @property
+    def config(self) -> PretrainedConfig:
+        return self._model.config
+
+    @property
+    def config_type(self) -> type:
+        return Phi3Config
+
+    @property
+    def parallel_blocks(self) -> bool:
+        return False
+
+    @property
+    def seqlen(self) -> int:
+        # if no sliding window, max_position_embeddings is same as original_max_position_embeddings
+        return self.config.max_position_embeddings
+
+    @property
+    def hidden_size(self) -> int:
+        return self.config.hidden_size
+
+    @property
+    def should_bake_mean_into_linear(self) -> bool:
+        return False
+
+    @property
+    def original_layer_type(self) -> type:
+        return Phi3DecoderLayer
+
+    @property
+    def original_layer_norm_type(self) -> type:
+        return Phi3RMSNorm
+
+    @property
+    def layer_adapter_type(self) -> type:
+        return Phi3LayerAdapter
+
+    @property
+    def compressed_layer_type(self) -> type:
+        return CompressedPhi3DecoderLayer
+
+    @property
+    def use_cache(self) -> bool:
+        return self.config.use_cache
+
+    @use_cache.setter
+    def use_cache(self, value: bool) -> None:
+        self.config.use_cache = value
+
+    def compute_output_logits(self, input_ids: Tensor) -> FloatTensor:
+        return self.model(input_ids=input_ids).logits
+
+    def convert_layer_to_compressed(self, layer: Module, layer_idx: int | None) -> Module:
+        compressed_layer = self.compressed_layer_type(cast(self.config_type, self.config), layer_idx).to(
+            self.config.torch_dtype
+        )
+        compressed_layer.load_state_dict(layer.state_dict(), strict=True)
+        return compressed_layer
+
+    def get_layers(self) -> list[LayerAdapter]:
+        return [self.layer_adapter_type(layer) for layer in self.model.model.layers]
+
+    def get_raw_layer_at(self, index: int) -> Module:
+        return self.model.model.layers[index]
+
+    def set_raw_layer_at(self, index: int, new_layer: Module) -> None:
+        self.model.model.layers[index] = new_layer
+
+    def get_embeddings(self) -> list[Module]:
+        return [self.model.model.embed_tokens]
+
+    def get_pre_head_layernorm(self) -> type:
+        pre_head_layernorm = self.model.model.norm
+        assert isinstance(pre_head_layernorm, self.original_layer_norm_type)
+        return pre_head_layernorm
+
+    def get_lm_head(self) -> Linear:
+        return self.model.lm_head
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        model_name: str,
+        model_path: str,
+        *,
+        dtype: torch.dtype = torch.float16,
+        local_files_only: bool = False,
+        token: str | bool | None = None,
+    ) -> ModelAdapter | None:
+        if not model_name.startswith("microsoft/Phi-3-mini-4k-instruct"):
+            return None
+
+        model = Phi3ForCausalLM.from_pretrained(
+            model_path, torch_dtype=dtype, token=token, local_files_only=local_files_only
+        )
+        model.config.torch_dtype = dtype
+
+        return Phi3ModelAdapter(model)
+
+    @classmethod
+    def _from_uninitialized(
+        cls,
+        model_name: str,
+        model_path: str,
+        *,
+        dtype: torch.dtype = torch.float16,
+        local_files_only: bool = False,
+        token: str | bool | None = None,
+    ) -> ModelAdapter | None:
+        if not model_name.startswith("microsoft/Phi-3-mini-4k-instruct"):
+            return None
+
+        class UninitializedPhi3ForCausalLM(Phi3ForCausalLM):
+            def _init_weights(self, _) -> None:
+                # Prevent weight initialization
+                pass
+
+        config = Phi3Config.from_pretrained(
+            model_path, torch_dtype=dtype, token=token, local_files_only=local_files_only
+        )
+        model = UninitializedPhi3ForCausalLM(config)
+        model = model.to(dtype=dtype)
+
+        return Phi3ModelAdapter(model)

--- a/src/slicegpt/adapters/phi3_adapter.py
+++ b/src/slicegpt/adapters/phi3_adapter.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import warnings
-from typing import Any, Optional, Tuple, cast
+from typing import Any, Optional, Tuple
 
 import torch
 from torch import FloatTensor, LongTensor, Tensor, matmul
@@ -203,9 +203,7 @@ class Phi3ModelAdapter(ModelAdapter):
         return self.model(input_ids=input_ids).logits
 
     def convert_layer_to_compressed(self, layer: Module, layer_idx: int | None) -> Module:
-        compressed_layer = self.compressed_layer_type(cast(self.config_type, self.config), layer_idx).to(
-            self.config.torch_dtype
-        )
+        compressed_layer = self.compressed_layer_type(self.config, layer_idx).to(self.config.torch_dtype)
         compressed_layer.load_state_dict(layer.state_dict(), strict=True)
         return compressed_layer
 
@@ -221,7 +219,7 @@ class Phi3ModelAdapter(ModelAdapter):
     def get_embeddings(self) -> list[Module]:
         return [self.model.model.embed_tokens]
 
-    def get_pre_head_layernorm(self) -> type:
+    def get_pre_head_layernorm(self) -> Module:
         pre_head_layernorm = self.model.model.norm
         assert isinstance(pre_head_layernorm, self.original_layer_norm_type)
         return pre_head_layernorm

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -10,11 +10,13 @@ from torch import Tensor
 from torch.nn import Module, Parameter
 from transformers.models.llama.modeling_llama import LlamaConfig, LlamaForCausalLM
 from transformers.models.opt.modeling_opt import OPTConfig, OPTForCausalLM
+from transformers.models.phi3.modeling_phi3 import Phi3Config, Phi3ForCausalLM
 from transformers.models.phi.modeling_phi import PhiConfig, PhiForCausalLM
 
 from slicegpt.adapters.llama_adapter import LlamaModelAdapter
 from slicegpt.adapters.opt_adapter import OPTModelAdapter
 from slicegpt.adapters.phi2_adapter import Phi2ModelAdapter
+from slicegpt.adapters.phi3_adapter import Phi3ModelAdapter
 from slicegpt.model_adapter import ModelAdapter
 
 
@@ -133,3 +135,19 @@ class TestPhi2Adapter(ModelAdapterTestBase):
         )
         model = PhiForCausalLM(config)
         return Phi2ModelAdapter(model)
+
+
+class TestPhi3Adapter(ModelAdapterTestBase):
+    def create_adapter(self) -> Phi3ModelAdapter:
+        config = Phi3Config(
+            vocab_size=32,
+            hidden_size=8,
+            intermediate_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            max_position_embeddings=16,
+            # must set 0 <= pad_token_id <= vocab_size unless set to None in config
+            pad_token_id=None,
+        )
+        model = Phi3ForCausalLM(config)
+        return Phi3ModelAdapter(model)


### PR DESCRIPTION
Adds [Phi-3-mini](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct) support. This requires updating transformers to _near_ latest. There hasn't been a release of transformers package since Phi-3 support was added. 

Dependencies: 
A commit from Friday in transformers package has an issue so updating transformers package to just before that commit. Once the issue is fixed, we can update to latest git commit of transformers and once there's a release, we can point to the latest package. 
Also updating `peft==0.6.2`. I have checked the slicing and finetuning for Phi-2 and run the tests. We get nearly the same results as the paper 
```
model: Phi-2
piqa: originial: 79.3, sliced@25% 74.5, recovery finetuned: 74.4
ppl on alpaca: original 2.98, sliced@25%: 3.22, recovery finetuned: 2.99
```

We can look at renaming the adapters: llama->llama2 and Phi-3->Phi-3-mini in a separate change. I have not tried the Phi-3-mini-128k version! We will need to figure out how to handle that too if we want to. 