### PR TITLE
QuaRot: KV cache quantization

### DIFF
--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -116,7 +116,7 @@ def quarot_arg_parser(interactive: bool = True) -> argparse.Namespace:
     parser.add_argument(
         '--tasks',
         nargs='+',
-        default=["piqa", "hellaswag", "arc_easy", "arc_challenge", "winogrande", "lambada"],
+        default=["piqa", "hellaswag", "arc_easy", "arc_challenge", "winogrande", "lambada_openai"],
     )
     parser.add_argument(
         '--lm-eval-batch-size', type=int, default=128, help='Batch size for evaluating with lm eval harness.'
@@ -214,7 +214,7 @@ def quarot_main(args: argparse.Namespace) -> None:
     if not args.lm_eval:
         return
 
-    hflm = HFLM(pretrained=model, tokenizer=tokenizer, batch_size=args.lm_eval_batch_size)
+    hflm = HFLM(pretrained=quarot_llama, tokenizer=tokenizer, batch_size=args.lm_eval_batch_size)
 
     initialize_tasks()
     task_names = lm_eval_utils.pattern_match(args.tasks, ALL_TASKS)

--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -111,6 +111,44 @@ def quarot_arg_parser(interactive: bool = True) -> argparse.Namespace:
         help='Clip ratio for activation quantization: new_max = max * clip_ratio.',
     )
 
+    # KV Quantization Arguments
+    parser.add_argument(
+        '--k-bits',
+        type=int,
+        default=16,
+        help='Number of bits to quantize the keys to.',
+    )
+    parser.add_argument(
+        '--k-clip-ratio',
+        type=float,
+        default=1.0,
+        help='Clip ratio for keys quantization: new_max = max * clip_ratio.',
+    )
+    parser.add_argument(
+        '--k-groupsize',
+        type=int,
+        default=None,
+        help='Group size for groupwise keys quantization.',
+    )
+    parser.add_argument(
+        '--v-bits',
+        type=int,
+        default=16,
+        help='Number of bits to quantize the values to.',
+    )
+    parser.add_argument(
+        '--v-clip-ratio',
+        type=float,
+        default=1.0,
+        help='Clip ratio for values quantization: new_max = max * clip_ratio.',
+    )
+    parser.add_argument(
+        '--v-groupsize',
+        type=int,
+        default=None,
+        help='Group size for groupwise values quantization.',
+    )
+
     # LM Eval Arguments
     parser.add_argument("--lm-eval", action="store_true", help="Evaluate the model on LM Eval tasks.")
     parser.add_argument(
@@ -195,6 +233,12 @@ def quarot_main(args: argparse.Namespace) -> None:
             rms_norm=rms_norm,
             act_bits=args.a_bits,
             act_clip_ratio=args.a_clip_ratio,
+            k_bits=args.k_bits,
+            k_clip_ratio=args.k_clip_ratio,
+            k_groupsize=args.k_groupsize,
+            v_bits=args.v_bits,
+            v_clip_ratio=args.v_clip_ratio,
+            v_groupsize=args.v_groupsize,
             config=model_config,
         )
 

--- a/src/quarot/nn/quantizer.py
+++ b/src/quarot/nn/quantizer.py
@@ -24,10 +24,7 @@ class ActQuantizer(torch.nn.Module):
         self.clip_ratio = clip_ratio
 
     def forward(self, x: torch.Tensor) -> PackedQuantizedTensor:
-        x_scales = (
-            calculate_scales_symmetric(x, self.bits, perchannel=True, clip_weights=False)
-            * self.clip_ratio
-        )
+        x_scales = calculate_scales_symmetric(x, self.bits, perchannel=True, clip_weights=False) * self.clip_ratio
         quantized_x = quantize_weight_rtn(x, x_scales, None, self.bits, symmetric=True)
         return PackedQuantizedTensor(quantized_x, x_scales)
 

--- a/src/quarot/nn/quantizer.py
+++ b/src/quarot/nn/quantizer.py
@@ -1,7 +1,7 @@
 import torch
 
 from quarot.quant_utils import PackedQuantizedTensor
-from quarot.rtn import calculate_scales, quantize_weight_rtn
+from quarot.rtn import calculate_scales_symmetric, quantize_weight_rtn
 
 
 class DummyActQuantizer(torch.nn.Module):
@@ -20,13 +20,31 @@ class ActQuantizer(torch.nn.Module):
     def __init__(self, bits: int, symmetric: bool = True, clip_ratio: float = 1.0) -> None:
         super().__init__()
         self.bits = bits
-        self.symmetric = symmetric
+        assert symmetric, "Activation quantization should be symmetric."
         self.clip_ratio = clip_ratio
 
     def forward(self, x: torch.Tensor) -> PackedQuantizedTensor:
         x_scales = (
-            calculate_scales(x, self.bits, symmetric=self.symmetric, perchannel=True, clip_weights=False)
+            calculate_scales_symmetric(x, self.bits, perchannel=True, clip_weights=False)
             * self.clip_ratio
         )
-        quantized_x = quantize_weight_rtn(x, x_scales, self.bits, self.symmetric)
+        quantized_x = quantize_weight_rtn(x, x_scales, None, self.bits, symmetric=True)
         return PackedQuantizedTensor(quantized_x, x_scales)
+
+
+# class KVQuantizer(torch.nn.Module):
+#     '''Quantizer for the KV caching.'''
+
+#     def __init__(self, bits: int, symmetric: bool = False, clip_ratio: float = 1.0) -> None:
+#         super().__init__()
+#         self.bits = bits
+#         self.symmetric = symmetric
+#         self.clip_ratio = clip_ratio
+
+#     def forward(self, x: torch.Tensor) -> PackedQuantizedTensor:
+#         x_scales, zeros = (
+#             calculate_scales_symmetric(x, self.bits, symmetric=self.symmetric, perchannel=True, clip_weights=False)
+#             * self.clip_ratio
+#         )
+#         quantized_x = quantize_weight_rtn(x, x_scales, self.bits, self.symmetric)
+#         return PackedQuantizedTensor(quantized_x, x_scales)

--- a/src/quarot/nn/quantizer.py
+++ b/src/quarot/nn/quantizer.py
@@ -1,7 +1,7 @@
 import torch
 
 from quarot.quant_utils import PackedQuantizedTensor
-from quarot.rtn import calculate_scales_symmetric, quantize_weight_rtn
+from quarot.rtn import calculate_scales_asymmetric, calculate_scales_symmetric, quantize_weight_rtn
 
 
 class DummyActQuantizer(torch.nn.Module):
@@ -29,19 +29,22 @@ class ActQuantizer(torch.nn.Module):
         return PackedQuantizedTensor(quantized_x, x_scales)
 
 
-# class KVQuantizer(torch.nn.Module):
-#     '''Quantizer for the KV caching.'''
+class KVQuantizerDequantizer(torch.nn.Module):
+    '''Quantizer for quantizing and immediately dequantizing K and V. Applies round-to-nearest quantization head-wise.'''
 
-#     def __init__(self, bits: int, symmetric: bool = False, clip_ratio: float = 1.0) -> None:
-#         super().__init__()
-#         self.bits = bits
-#         self.symmetric = symmetric
-#         self.clip_ratio = clip_ratio
+    def __init__(
+        self, bits: int, symmetric: bool = False, clip_ratio: float = 1.0, groupsize: int | None = None
+    ) -> None:
+        super().__init__()
+        self.bits = bits
+        assert not symmetric, "KV quantization should be asymmetric."
+        self.clip_ratio = clip_ratio
+        self.groupsize = groupsize
 
-#     def forward(self, x: torch.Tensor) -> PackedQuantizedTensor:
-#         x_scales, zeros = (
-#             calculate_scales_symmetric(x, self.bits, symmetric=self.symmetric, perchannel=True, clip_weights=False)
-#             * self.clip_ratio
-#         )
-#         quantized_x = quantize_weight_rtn(x, x_scales, self.bits, self.symmetric)
-#         return PackedQuantizedTensor(quantized_x, x_scales)
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_scales, x_offsets = calculate_scales_asymmetric(
+            x, self.bits, perchannel=True, clip_ratio=self.clip_ratio, groupsize=self.groupsize
+        )
+        quantized_x = quantize_weight_rtn(x, x_scales, x_offsets, self.bits, symmetric=False)
+        dequantized_x = (quantized_x - x_offsets) * x_scales
+        return dequantized_x

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -7,45 +7,24 @@ from tqdm import tqdm
 from quarot.nn.linear import QuarotFP16Linear
 
 
-def calculate_max_int(bits: int, symmetric: bool = True) -> torch.Tensor:
+def calculate_min_max_int(bits: int, symmetric: bool = True) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Calculate the maximum representable integer value given the number of bits and the quantization scheme.
     """
     if symmetric:
         max_int = torch.tensor(2 ** (bits - 1) - 1)
+        min_int = - (max_int + 1)
     else:
-        raise NotImplementedError("Asymmetric quantization not implemented yet.")
-    return max_int
+        max_int = torch.tensor(2**bits - 1)
+        min_int = torch.zeros(1)
+    return min_int, max_int
 
 
-def quantize_weight_rtn(weight: torch.Tensor, scale: torch.Tensor, bits: int, symmetric: bool = True) -> torch.Tensor:
+def calculate_min_max_weight(weight: torch.Tensor, symmetric: bool = True, perchannel: bool = True) -> tuple[torch.Tensor, torch.Tensor]:
     """
-    Quantize a weight tensor to INT<bits> using the given scale.
+    Calculate the minimum and maximum weights in a weight tensor. If perchannel, these are calculated per-row. If symmetric, the max weight is
+    the larger of max weight or the absolute value of min weight. 
     """
-    device = weight.device
-    weight = weight.cuda()
-    scale = scale.cuda()
-
-    if symmetric:
-        max_int = calculate_max_int(bits, symmetric).to(device=weight.device)
-        quantized_weight = torch.clamp(torch.round(weight / scale), -(max_int + 1), max_int)
-    else:
-        raise NotImplementedError("Asymmetric quantization not implemented yet.")
-
-    quantized_weight = quantized_weight.to(device)
-    return quantized_weight
-
-
-def calculate_scales(
-    weight: torch.Tensor, bits: int, symmetric: bool = True, perchannel: bool = True, clip_weights=True
-) -> torch.Tensor:
-    """
-    Calculate the scales for quantizing a weight tensor to INT<bits> using the Round-to-Nearest scheme. If clip_weights is True,
-    the scales are found using a grid search to minimize the quantization error.
-    """
-    device = weight.device
-    weight = weight.cuda()
-
     if perchannel:
         max_weight = torch.max(weight, torch.zeros_like(weight)).max(dim=-1, keepdim=True).values
         min_weight = torch.min(weight, torch.zeros_like(weight)).min(dim=-1, keepdim=True).values
@@ -54,11 +33,26 @@ def calculate_scales(
         min_weight = torch.min(weight, torch.zeros_like(weight)).min()
 
     if symmetric:
-        max_weight = torch.maximum(max_weight, -min_weight).clamp(min=1e-5)
-        max_int = calculate_max_int(bits, symmetric).to(device=weight.device)
-        weight_scales = max_weight / max_int
-    else:
-        raise NotImplementedError("Asymmetric quantization not implemented yet.")
+        max_weight = torch.maximum(max_weight, torch.abs(min_weight)).clamp(min=1e-5)
+    
+    return min_weight, max_weight
+
+
+def calculate_scales_symmetric(
+    weight: torch.Tensor, bits: int, perchannel: bool = True, clip_weights=True
+) -> torch.Tensor:
+    """
+    Calculate the scales for symmetric quantization of a weight tensor to INT<bits> using the Round-to-Nearest scheme. If clip_weights is True,
+    the scales are found using a grid search to minimize the quantization error.
+    """
+    device = weight.device
+    weight = weight.cuda()
+    _, max_weight = calculate_min_max_weight(weight, symmetric=True, perchannel=perchannel)
+    _, max_int = calculate_min_max_int(bits, symmetric=True)
+
+    # Calculate the scales
+    max_int = max_int.to(device=weight.device)
+    weight_scales = max_weight / max_int
 
     if clip_weights:
         # Perform a grid search to find the best weight scales according to quantization error.
@@ -70,18 +64,15 @@ def calculate_scales(
         shrink_factors = torch.linspace(1.0, 1 - max_shrink_factor, n_steps)
         candidate_max_weights = shrink_factors.to(weight.device) * max_weight
 
-        if symmetric:
-            candidate_scales = candidate_max_weights / max_int
-            candidate_scales = candidate_scales.unsqueeze(1)
-            weight = weight.unsqueeze(-1)
+        candidate_scales = candidate_max_weights / max_int
+        candidate_scales = candidate_scales.unsqueeze(1)
+        weight = weight.unsqueeze(-1)
 
-            # Quantize weights
-            candidate_quantized_weights = quantize_weight_rtn(weight, candidate_scales, bits, symmetric)
+        # Quantize weights
+        candidate_quantized_weights = quantize_weight_rtn(weight, candidate_scales, None, bits, symmetric=True)
 
-            # Dequantize weights
-            reconstructed_weights = candidate_quantized_weights * candidate_scales
-        else:
-            raise NotImplementedError("Asymmetric quantization not implemented yet.")
+        # Dequantize weights
+        reconstructed_weights = candidate_quantized_weights * candidate_scales
 
         # Compute quantization error and find the best scale for each weight
         quantization_errors = torch.sum(torch.abs(reconstructed_weights - weight).pow_(error_norm), 1)
@@ -90,7 +81,50 @@ def calculate_scales(
 
     weight = weight.to(device)
     weight_scales = weight_scales.to(device)
+
     return weight_scales
+
+
+def calculate_scales_asymmetric(
+    weight: torch.Tensor, bits: int, perchannel: bool = True
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Calculate the scales and offsets for asymmetric quantization a weight tensor to INT<bits> using the Round-to-Nearest scheme.
+    """
+    device = weight.device
+    weight = weight.cuda()
+    min_weight, max_weight = calculate_min_max_weight(weight, symmetric=False, perchannel=perchannel)
+    _, max_int = calculate_min_max_int(bits, symmetric=False)
+
+    # Calculate scales and offsets
+    weight_scales = (max_weight - min_weight) / max_int
+    weight_offsets = torch.round(-min_weight / weight_scales)
+
+    weight = weight.to(device)
+    weight_scales = weight_scales.to(device)
+    weight_offsets = weight_offsets.to(device)
+    return weight_scales, weight_offsets
+
+
+def quantize_weight_rtn(weight: torch.Tensor, scale: torch.Tensor, offset: torch.Tensor | None, bits: int, symmetric: bool = True) -> torch.Tensor:
+    """
+    Quantize a weight tensor to INT<bits> using the given scale and offset.
+    """
+    device = weight.device
+    weight = weight.cuda()
+    scale = scale.cuda()
+
+    min_int, max_int = calculate_min_max_int(bits, symmetric)
+    min_int = min_int.to(device=weight.device)
+    max_int = max_int.to(device=weight.device)
+    if symmetric:
+        quantized_weight = torch.clamp(torch.round(weight / scale), min_int, max_int)
+    else:
+        offset = offset.to(device=weight.device)
+        quantized_weight = torch.clamp(torch.round(weight / scale) + offset, min_int, max_int)
+
+    quantized_weight = quantized_weight.to(device)
+    return quantized_weight
 
 
 def quantize_module_rtn(
@@ -101,8 +135,13 @@ def quantize_module_rtn(
     scales are stored in the module's weight_scales buffer, and are also stored in torch.float16.
     """
     weight = module.weight
-    weight_scales = calculate_scales(weight, bits, symmetric, perchannel, clip_weights)
-    quantized_weight = quantize_weight_rtn(weight, weight_scales, bits, symmetric)
+    offset = None
+    if symmetric:
+        weight_scales = calculate_scales_symmetric(weight, bits, perchannel, clip_weights)
+    else:
+        weight_scales, offset = calculate_scales_asymmetric(weight, bits, perchannel)
+
+    quantized_weight = quantize_weight_rtn(weight, weight_scales, offset, bits, symmetric)
 
     module.weight.data = quantized_weight
     module.weight_scales = weight_scales

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -13,17 +13,19 @@ def calculate_min_max_int(bits: int, symmetric: bool = True) -> tuple[torch.Tens
     """
     if symmetric:
         max_int = torch.tensor(2 ** (bits - 1) - 1)
-        min_int = - (max_int + 1)
+        min_int = -(max_int + 1)
     else:
         max_int = torch.tensor(2**bits - 1)
         min_int = torch.zeros(1)
     return min_int, max_int
 
 
-def calculate_min_max_weight(weight: torch.Tensor, symmetric: bool = True, perchannel: bool = True) -> tuple[torch.Tensor, torch.Tensor]:
+def calculate_min_max_weight(
+    weight: torch.Tensor, symmetric: bool = True, perchannel: bool = True
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Calculate the minimum and maximum weights in a weight tensor. If perchannel, these are calculated per-row. If symmetric, the max weight is
-    the larger of max weight or the absolute value of min weight. 
+    the larger of max weight or the absolute value of min weight.
     """
     if perchannel:
         max_weight = torch.max(weight, torch.zeros_like(weight)).max(dim=-1, keepdim=True).values
@@ -34,7 +36,7 @@ def calculate_min_max_weight(weight: torch.Tensor, symmetric: bool = True, perch
 
     if symmetric:
         max_weight = torch.maximum(max_weight, torch.abs(min_weight)).clamp(min=1e-5)
-    
+
     return min_weight, max_weight
 
 
@@ -106,7 +108,9 @@ def calculate_scales_asymmetric(
     return weight_scales, weight_offsets
 
 
-def quantize_weight_rtn(weight: torch.Tensor, scale: torch.Tensor, offset: torch.Tensor | None, bits: int, symmetric: bool = True) -> torch.Tensor:
+def quantize_weight_rtn(
+    weight: torch.Tensor, scale: torch.Tensor, offset: torch.Tensor | None, bits: int, symmetric: bool = True
+) -> torch.Tensor:
     """
     Quantize a weight tensor to INT<bits> using the given scale and offset.
     """

--- a/tests/test_rtn.py
+++ b/tests/test_rtn.py
@@ -4,7 +4,7 @@
 import pytest
 import torch
 
-from quarot.rtn import calculate_scales_symmetric, quantize_weight_rtn, calculate_scales_asymmetric
+from quarot.rtn import calculate_scales_asymmetric, calculate_scales_symmetric, quantize_weight_rtn
 
 
 @pytest.mark.quarot


### PR DESCRIPTION
Reproduces Tables 10 and 11 to within 0.01 PPL -> KV cache quantization (with no other quantization in model) working fully as expected.

Tested weight, activation and KV cache quantization i.e. end-to-end RTN: reproduces full 6- and 8-bit PPL results. For full 4-bit we get: 

Llama-2 7B: 8.60 vs 8.37 in paper (i.e. 0.23 worse)
Llama-2 13B: 6.34 vs 6.09 in paper (i.e. 0.25 worse)
