### PR TITLE
QuaRot: Add activation and KV cache quantization

### DIFF
--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -111,12 +111,50 @@ def quarot_arg_parser(interactive: bool = True) -> argparse.Namespace:
         help='Clip ratio for activation quantization: new_max = max * clip_ratio.',
     )
 
+    # KV Quantization Arguments
+    parser.add_argument(
+        '--k-bits',
+        type=int,
+        default=16,
+        help='Number of bits to quantize the keys to.',
+    )
+    parser.add_argument(
+        '--k-clip-ratio',
+        type=float,
+        default=1.0,
+        help='Clip ratio for keys quantization: new_max = max * clip_ratio.',
+    )
+    parser.add_argument(
+        '--k-groupsize',
+        type=int,
+        default=None,
+        help='Group size for groupwise keys quantization.',
+    )
+    parser.add_argument(
+        '--v-bits',
+        type=int,
+        default=16,
+        help='Number of bits to quantize the values to.',
+    )
+    parser.add_argument(
+        '--v-clip-ratio',
+        type=float,
+        default=1.0,
+        help='Clip ratio for values quantization: new_max = max * clip_ratio.',
+    )
+    parser.add_argument(
+        '--v-groupsize',
+        type=int,
+        default=None,
+        help='Group size for groupwise values quantization.',
+    )
+
     # LM Eval Arguments
     parser.add_argument("--lm-eval", action="store_true", help="Evaluate the model on LM Eval tasks.")
     parser.add_argument(
         '--tasks',
         nargs='+',
-        default=["piqa", "hellaswag", "arc_easy", "arc_challenge", "winogrande", "lambada"],
+        default=["piqa", "hellaswag", "arc_easy", "arc_challenge", "winogrande", "lambada_openai"],
     )
     parser.add_argument(
         '--lm-eval-batch-size', type=int, default=128, help='Batch size for evaluating with lm eval harness.'
@@ -195,6 +233,12 @@ def quarot_main(args: argparse.Namespace) -> None:
             rms_norm=rms_norm,
             act_bits=args.a_bits,
             act_clip_ratio=args.a_clip_ratio,
+            k_bits=args.k_bits,
+            k_clip_ratio=args.k_clip_ratio,
+            k_groupsize=args.k_groupsize,
+            v_bits=args.v_bits,
+            v_clip_ratio=args.v_clip_ratio,
+            v_groupsize=args.v_groupsize,
             config=model_config,
         )
 
@@ -214,7 +258,7 @@ def quarot_main(args: argparse.Namespace) -> None:
     if not args.lm_eval:
         return
 
-    hflm = HFLM(pretrained=model, tokenizer=tokenizer, batch_size=args.lm_eval_batch_size)
+    hflm = HFLM(pretrained=quarot_llama, tokenizer=tokenizer, batch_size=args.lm_eval_batch_size)
 
     initialize_tasks()
     task_names = lm_eval_utils.pattern_match(args.tasks, ALL_TASKS)

--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -93,7 +93,7 @@ def quarot_arg_parser(interactive: bool = True) -> argparse.Namespace:
     parser.add_argument(
         '--w-bits',
         type=int,
-        default=4,
+        default=16,
         help='Number of bits to quantize the weights to.',
     )
 

--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -97,6 +97,20 @@ def quarot_arg_parser(interactive: bool = True) -> argparse.Namespace:
         help='Number of bits to quantize the weights to.',
     )
 
+    # Activation Quantization Arguments
+    parser.add_argument(
+        '--a-bits',
+        type=int,
+        default=16,
+        help='Number of bits to quantize the weights to.',
+    )
+    parser.add_argument(
+        '--a-clip-ratio',
+        type=float,
+        default=1.0,
+        help='Clip ratio for activation quantization: new_max = max * clip_ratio.',
+    )
+
     # LM Eval Arguments
     parser.add_argument("--lm-eval", action="store_true", help="Evaluate the model on LM Eval tasks.")
     parser.add_argument(
@@ -176,7 +190,12 @@ def quarot_main(args: argparse.Namespace) -> None:
         online_had_attn = True if args.rotate else False
         rms_norm = True if args.rotate else False
         quarot_llama = QuarotLlamaForCausalLM(
-            online_had_mlp=online_had_mlp, online_had_attn=online_had_attn, rms_norm=rms_norm, config=model_config
+            online_had_mlp=online_had_mlp,
+            online_had_attn=online_had_attn,
+            rms_norm=rms_norm,
+            act_bits=args.a_bits,
+            act_clip_ratio=args.a_clip_ratio,
+            config=model_config,
         )
 
         # load the rotated weights into the quarot model

--- a/src/quarot/nn/__init__.py
+++ b/src/quarot/nn/__init__.py
@@ -1,3 +1,2 @@
 from .hadamard import OnlineHadamard
 from .linear import QuarotFP16Linear
-from .quantizer import DummyActQuantizer

--- a/src/quarot/nn/quantizer.py
+++ b/src/quarot/nn/quantizer.py
@@ -1,7 +1,7 @@
 import torch
 
 from quarot.quant_utils import PackedQuantizedTensor
-from quarot.rtn import calculate_scales, quantize_weight_rtn
+from quarot.rtn import calculate_scales_asymmetric, calculate_scales_symmetric, quantize_weight_rtn
 
 
 class DummyActQuantizer(torch.nn.Module):
@@ -20,13 +20,31 @@ class ActQuantizer(torch.nn.Module):
     def __init__(self, bits: int, symmetric: bool = True, clip_ratio: float = 1.0) -> None:
         super().__init__()
         self.bits = bits
-        self.symmetric = symmetric
+        assert symmetric, "Activation quantization should be symmetric."
         self.clip_ratio = clip_ratio
 
     def forward(self, x: torch.Tensor) -> PackedQuantizedTensor:
-        x_scales = (
-            calculate_scales(x, self.bits, symmetric=self.symmetric, perchannel=True, clip_weights=False)
-            * self.clip_ratio
-        )
-        quantized_x = quantize_weight_rtn(x, x_scales, self.bits, self.symmetric)
+        x_scales = calculate_scales_symmetric(x, self.bits, perchannel=True, clip_weights=False) * self.clip_ratio
+        quantized_x = quantize_weight_rtn(x, x_scales, None, self.bits, symmetric=True)
         return PackedQuantizedTensor(quantized_x, x_scales)
+
+
+class KVQuantizerDequantizer(torch.nn.Module):
+    '''Quantizer for quantizing and immediately dequantizing K and V. Applies round-to-nearest quantization head-wise.'''
+
+    def __init__(
+        self, bits: int, symmetric: bool = False, clip_ratio: float = 1.0, groupsize: int | None = None
+    ) -> None:
+        super().__init__()
+        self.bits = bits
+        assert not symmetric, "KV quantization should be asymmetric."
+        self.clip_ratio = clip_ratio
+        self.groupsize = groupsize
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_scales, x_offsets = calculate_scales_asymmetric(
+            x, self.bits, perchannel=True, clip_ratio=self.clip_ratio, groupsize=self.groupsize
+        )
+        quantized_x = quantize_weight_rtn(x, x_scales, x_offsets, self.bits, symmetric=False)
+        dequantized_x = (quantized_x - x_offsets) * x_scales
+        return dequantized_x

--- a/src/quarot/nn/quantizer.py
+++ b/src/quarot/nn/quantizer.py
@@ -17,7 +17,7 @@ class DummyActQuantizer(torch.nn.Module):
 class ActQuantizer(torch.nn.Module):
     '''Quantizer for activations. Applies round-to-nearest quantization tensor-wise across the seqlen and hidden_dim dimensions.'''
 
-    def __init__(self, bits: int, symmetric: bool, clip_ratio: float = 1.0) -> None:
+    def __init__(self, bits: int, symmetric: bool = True, clip_ratio: float = 1.0) -> None:
         super().__init__()
         self.bits = bits
         self.symmetric = symmetric
@@ -25,7 +25,7 @@ class ActQuantizer(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> PackedQuantizedTensor:
         x_scales = (
-            calculate_scales(x, self.bits, symmetric=self.symmetric, perchannel=False, clip_weights=False)
+            calculate_scales(x, self.bits, symmetric=self.symmetric, perchannel=True, clip_weights=False)
             * self.clip_ratio
         )
         quantized_x = quantize_weight_rtn(x, x_scales, self.bits, self.symmetric)

--- a/src/quarot/nn/quantizer.py
+++ b/src/quarot/nn/quantizer.py
@@ -1,6 +1,7 @@
 import torch
 
 from quarot.quant_utils import PackedQuantizedTensor
+from quarot.rtn import calculate_scales, quantize_weight_rtn
 
 
 class DummyActQuantizer(torch.nn.Module):
@@ -11,3 +12,21 @@ class DummyActQuantizer(torch.nn.Module):
         shape = x.shape[:-1] + (1,)
         scales_x = torch.ones(shape, device=x.device, dtype=x.dtype)
         return PackedQuantizedTensor(x, scales_x)
+
+
+class ActQuantizer(torch.nn.Module):
+    '''Quantizer for activations. Applies round-to-nearest quantization tensor-wise across the seqlen and hidden_dim dimensions.'''
+
+    def __init__(self, bits: int, symmetric: bool, clip_ratio: float = 1.0) -> None:
+        super().__init__()
+        self.bits = bits
+        self.symmetric = symmetric
+        self.clip_ratio = clip_ratio
+
+    def forward(self, x: torch.Tensor) -> PackedQuantizedTensor:
+        x_scales = (
+            calculate_scales(x, self.bits, symmetric=self.symmetric, perchannel=False, clip_weights=False)
+            * self.clip_ratio
+        )
+        quantized_x = quantize_weight_rtn(x, x_scales, self.bits, self.symmetric)
+        return PackedQuantizedTensor(quantized_x, x_scales)

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -50,7 +50,8 @@ def calculate_scales(
         max_weight = torch.max(weight, torch.zeros_like(weight)).max(dim=1, keepdim=True).values
         min_weight = torch.min(weight, torch.zeros_like(weight)).min(dim=1, keepdim=True).values
     else:
-        raise NotImplementedError("Tensor-wise quantization not implemented yet.")
+        max_weight = torch.max(weight, torch.zeros_like(weight)).max()
+        min_weight = torch.min(weight, torch.zeros_like(weight)).min()
 
     if symmetric:
         max_weight = torch.maximum(max_weight, -min_weight).clamp(min=1e-5)

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -7,45 +7,26 @@ from tqdm import tqdm
 from quarot.nn.linear import QuarotFP16Linear
 
 
-def calculate_max_int(bits: int, symmetric: bool = True) -> torch.Tensor:
+def calculate_min_max_int(bits: int, symmetric: bool = True) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Calculate the maximum representable integer value given the number of bits and the quantization scheme.
     """
     if symmetric:
         max_int = torch.tensor(2 ** (bits - 1) - 1)
+        min_int = -(max_int + 1)
     else:
-        raise NotImplementedError("Asymmetric quantization not implemented yet.")
-    return max_int
+        max_int = torch.tensor(2**bits - 1)
+        min_int = torch.zeros(1)
+    return min_int, max_int
 
 
-def quantize_weight_rtn(weight: torch.Tensor, scale: torch.Tensor, bits: int, symmetric: bool = True) -> torch.Tensor:
+def calculate_min_max_weight(
+    weight: torch.Tensor, symmetric: bool = True, perchannel: bool = True
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
-    Quantize a weight tensor to INT<bits> using the given scale.
+    Calculate the minimum and maximum weights in a weight tensor. If perchannel, these are calculated per-row. If symmetric, the max weight is
+    the larger of max weight or the absolute value of min weight.
     """
-    device = weight.device
-    weight = weight.cuda()
-    scale = scale.cuda()
-
-    if symmetric:
-        max_int = calculate_max_int(bits, symmetric).to(device=weight.device)
-        quantized_weight = torch.clamp(torch.round(weight / scale), -(max_int + 1), max_int)
-    else:
-        raise NotImplementedError("Asymmetric quantization not implemented yet.")
-
-    quantized_weight = quantized_weight.to(device)
-    return quantized_weight
-
-
-def calculate_scales(
-    weight: torch.Tensor, bits: int, symmetric: bool = True, perchannel: bool = True, clip_weights=True
-) -> torch.Tensor:
-    """
-    Calculate the scales for quantizing a weight tensor to INT<bits> using the Round-to-Nearest scheme. If clip_weights is True,
-    the scales are found using a grid search to minimize the quantization error.
-    """
-    device = weight.device
-    weight = weight.cuda()
-
     if perchannel:
         max_weight = torch.max(weight, torch.zeros_like(weight)).max(dim=-1, keepdim=True).values
         min_weight = torch.min(weight, torch.zeros_like(weight)).min(dim=-1, keepdim=True).values
@@ -54,11 +35,26 @@ def calculate_scales(
         min_weight = torch.min(weight, torch.zeros_like(weight)).min()
 
     if symmetric:
-        max_weight = torch.maximum(max_weight, -min_weight).clamp(min=1e-5)
-        max_int = calculate_max_int(bits, symmetric).to(device=weight.device)
-        weight_scales = max_weight / max_int
-    else:
-        raise NotImplementedError("Asymmetric quantization not implemented yet.")
+        max_weight = torch.maximum(max_weight, torch.abs(min_weight)).clamp(min=1e-5)
+
+    return min_weight, max_weight
+
+
+def calculate_scales_symmetric(
+    weight: torch.Tensor, bits: int, perchannel: bool = True, clip_weights=True
+) -> torch.Tensor:
+    """
+    Calculate the scales for symmetric quantization of a weight tensor to INT<bits> using the Round-to-Nearest scheme. If clip_weights is True,
+    the scales are found using a grid search to minimize the quantization error.
+    """
+    device = weight.device
+    weight = weight.cuda()
+    _, max_weight = calculate_min_max_weight(weight, symmetric=True, perchannel=perchannel)
+    _, max_int = calculate_min_max_int(bits, symmetric=True)
+
+    # Calculate the scales
+    max_int = max_int.to(device=weight.device)
+    scale = max_weight / max_int
 
     if clip_weights:
         # Perform a grid search to find the best weight scales according to quantization error.
@@ -70,46 +66,115 @@ def calculate_scales(
         shrink_factors = torch.linspace(1.0, 1 - max_shrink_factor, n_steps)
         candidate_max_weights = shrink_factors.to(weight.device) * max_weight
 
-        if symmetric:
-            candidate_scales = candidate_max_weights / max_int
-            candidate_scales = candidate_scales.unsqueeze(1)
-            weight = weight.unsqueeze(-1)
+        candidate_scales = candidate_max_weights / max_int
+        candidate_scales = candidate_scales.unsqueeze(1)
+        weight = weight.unsqueeze(-1)
 
-            # Quantize weights
-            candidate_quantized_weights = quantize_weight_rtn(weight, candidate_scales, bits, symmetric)
+        # Quantize weights
+        candidate_quantized_weights = quantize_weight_rtn(weight, candidate_scales, None, bits, symmetric=True)
 
-            # Dequantize weights
-            reconstructed_weights = candidate_quantized_weights * candidate_scales
-        else:
-            raise NotImplementedError("Asymmetric quantization not implemented yet.")
+        # Dequantize weights
+        reconstructed_weights = candidate_quantized_weights * candidate_scales
 
         # Compute quantization error and find the best scale for each weight
         quantization_errors = torch.sum(torch.abs(reconstructed_weights - weight).pow_(error_norm), 1)
         best_scale_indices = torch.argmin(quantization_errors, dim=-1)
-        weight_scales = torch.gather(candidate_scales.squeeze(1), 1, best_scale_indices.unsqueeze(1))
+        scale = torch.gather(candidate_scales.squeeze(1), 1, best_scale_indices.unsqueeze(1))
 
     weight = weight.to(device)
-    weight_scales = weight_scales.to(device)
-    return weight_scales
+    scale = scale.to(device)
+
+    return scale
+
+
+def calculate_scales_asymmetric(
+    weight: torch.Tensor, bits: int, perchannel: bool = True, clip_ratio: float = 1.0, groupsize: int | None = None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Calculate the scales and offsets for asymmetric quantization a weight tensor to INT<bits> using the Round-to-Nearest scheme.
+    """
+    device = weight.device
+    weight = weight.cuda()
+
+    if groupsize:
+        init_shape = weight.shape
+        weight = weight.reshape(-1, weight.shape[-2], weight.shape[-1] // groupsize, groupsize)
+
+    min_weight, max_weight = calculate_min_max_weight(weight, symmetric=False, perchannel=perchannel)
+    min_weight *= clip_ratio
+    max_weight *= clip_ratio
+
+    _, max_int = calculate_min_max_int(bits, symmetric=False)
+
+    # Calculate scales and offsets
+    scale = (max_weight - min_weight) / max_int
+    offset = torch.round(-min_weight / scale)
+
+    if groupsize:
+        scale = scale.repeat(1, 1, 1, groupsize).reshape(init_shape)
+        offset = offset.repeat(1, 1, 1, groupsize).reshape(init_shape)
+
+    weight = weight.to(device)
+    scale = scale.to(device)
+    offset = offset.to(device)
+    return scale, offset
+
+
+def quantize_weight_rtn(
+    weight: torch.Tensor, scale: torch.Tensor, offset: torch.Tensor | None, bits: int, symmetric: bool = True
+) -> torch.Tensor:
+    """
+    Quantize a weight tensor to INT<bits> using the given scale and offset.
+    """
+    device = weight.device
+    weight = weight.cuda()
+    scale = scale.cuda()
+
+    min_int, max_int = calculate_min_max_int(bits, symmetric)
+    min_int = min_int.to(device=weight.device)
+    max_int = max_int.to(device=weight.device)
+    if symmetric:
+        quantized_weight = torch.clamp(torch.round(weight / scale), min_int, max_int)
+    else:
+        offset = offset.to(device=weight.device)
+        quantized_weight = torch.clamp(torch.round(weight / scale) + offset, min_int, max_int)
+
+    quantized_weight = quantized_weight.to(device)
+    return quantized_weight
 
 
 def quantize_module_rtn(
-    module: QuarotFP16Linear, bits: int, symmetric: bool = True, perchannel: bool = True, clip_weights: bool = True
+    module: QuarotFP16Linear,
+    bits: int,
+    symmetric: bool = True,
+    perchannel: bool = True,
+    clip_weights: bool = True,
+    groupsize: int | None = None,
 ) -> None:
     """
     Quantize the weights of a QuarotFP16Linear module to INT<bits> using the Round-to-Nearest scheme, storing the weights in torch.float16. The weight
     scales are stored in the module's weight_scales buffer, and are also stored in torch.float16.
     """
     weight = module.weight
-    weight_scales = calculate_scales(weight, bits, symmetric, perchannel, clip_weights)
-    quantized_weight = quantize_weight_rtn(weight, weight_scales, bits, symmetric)
+    offset = None
+    if symmetric:
+        scale = calculate_scales_symmetric(weight, bits, perchannel, clip_weights)
+    else:
+        scale, offset = calculate_scales_asymmetric(weight, bits, perchannel, groupsize)
+
+    quantized_weight = quantize_weight_rtn(weight, scale, offset, bits, symmetric)
 
     module.weight.data = quantized_weight
-    module.weight_scales = weight_scales
+    module.weight_scales = scale
 
 
 def quantize_model_rtn(
-    model, bits: int, symmetric: bool = True, perchannel: bool = True, clip_weights: bool = True
+    model,
+    bits: int,
+    symmetric: bool = True,
+    perchannel: bool = True,
+    clip_weights: bool = True,
+    groupsize: int | None = None,
 ) -> None:
     """
     Quantize the weights of a model using the Round-to-Nearest scheme.
@@ -123,10 +188,10 @@ def quantize_model_rtn(
     """
     layers = model.model.layers
     for layer in tqdm(layers, desc="Quantizing layers", unit="layer"):
-        quantize_module_rtn(layer.mlp.up_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.mlp.gate_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.mlp.down_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.self_attn.q_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.self_attn.k_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.self_attn.v_proj, bits, symmetric, perchannel, clip_weights)
-        quantize_module_rtn(layer.self_attn.o_proj, bits, symmetric, perchannel, clip_weights)
+        quantize_module_rtn(layer.mlp.up_proj, bits, symmetric, perchannel, clip_weights, groupsize)
+        quantize_module_rtn(layer.mlp.gate_proj, bits, symmetric, perchannel, clip_weights, groupsize)
+        quantize_module_rtn(layer.mlp.down_proj, bits, symmetric, perchannel, clip_weights, groupsize)
+        quantize_module_rtn(layer.self_attn.q_proj, bits, symmetric, perchannel, clip_weights, groupsize)
+        quantize_module_rtn(layer.self_attn.k_proj, bits, symmetric, perchannel, clip_weights, groupsize)
+        quantize_module_rtn(layer.self_attn.v_proj, bits, symmetric, perchannel, clip_weights, groupsize)
+        quantize_module_rtn(layer.self_attn.o_proj, bits, symmetric, perchannel, clip_weights, groupsize)

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -47,8 +47,8 @@ def calculate_scales(
     weight = weight.cuda()
 
     if perchannel:
-        max_weight = torch.max(weight, torch.zeros_like(weight)).max(dim=1, keepdim=True).values
-        min_weight = torch.min(weight, torch.zeros_like(weight)).min(dim=1, keepdim=True).values
+        max_weight = torch.max(weight, torch.zeros_like(weight)).max(dim=-1, keepdim=True).values
+        min_weight = torch.min(weight, torch.zeros_like(weight)).min(dim=-1, keepdim=True).values
     else:
         max_weight = torch.max(weight, torch.zeros_like(weight)).max()
         min_weight = torch.min(weight, torch.zeros_like(weight)).min()

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -4,22 +4,40 @@
 import pytest
 import torch
 
-from quarot.nn.quantizer import DummyActQuantizer
+from quarot.nn.quantizer import ActQuantizer, DummyActQuantizer
 
 
 @pytest.mark.quarot
 def test_dummy_quantizer():
-    """Sanity checks for emulated quantization."""
-
     quantizer = DummyActQuantizer()
 
-    x = torch.tensor([1.02, 0.056, -3.2, 4.999, 5.0])
+    act = torch.tensor([1.02, 0.056, -3.2, 4.999, 5.0])
 
-    packed_tensor = quantizer(x)
+    packed_quantized_act = quantizer(act)
+    quantized_x, scales_x = packed_quantized_act.quantized_x, packed_quantized_act.scales_x
 
-    quantized_x = packed_tensor.quantized_x
-    scales_x = packed_tensor.scales_x
-
+    # Check quantization error
     dequantized_x = quantized_x * scales_x
+    assert torch.allclose(act, dequantized_x)
 
-    assert torch.allclose(dequantized_x, x, atol=1e-3, rtol=1e-3)
+
+@pytest.mark.quarot
+@pytest.mark.gpu
+def test_act_quantizer():
+    quantizer = ActQuantizer(bits=8)
+
+    batch_size = 2
+    seq_len = 4
+    hidden_dim = 8
+    act = torch.randn(batch_size, seq_len, hidden_dim)
+
+    packed_quantized_act = quantizer(act)
+    quantized_act, act_scales = packed_quantized_act.quantized_x, packed_quantized_act.scales_x
+
+    # Check shapes
+    assert quantized_act.shape == (batch_size, seq_len, hidden_dim)
+    assert act_scales.shape == (batch_size, seq_len, 1)
+
+    # Check quantization error
+    dequantized_act = quantized_act * act_scales
+    assert torch.allclose(act, dequantized_act, rtol=1e-2, atol=1e-2)

--- a/tests/test_rtn.py
+++ b/tests/test_rtn.py
@@ -4,7 +4,7 @@
 import pytest
 import torch
 
-from quarot.rtn import calculate_scales, quantize_weight_rtn
+from quarot.rtn import calculate_scales_asymmetric, calculate_scales_symmetric, quantize_weight_rtn
 
 
 @pytest.mark.quarot
@@ -22,8 +22,8 @@ from quarot.rtn import calculate_scales, quantize_weight_rtn
         ),
     ],
 )
-def test_calculate_scales(bits, weight, expected_scales):
-    scales = calculate_scales(weight, bits, symmetric=True, perchannel=True, clip_weights=False)
+def test_calculate_scales_symmetric(bits, weight, expected_scales):
+    scales = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=False)
     assert torch.allclose(scales, expected_scales)
 
 
@@ -41,7 +41,86 @@ def test_calculate_scales(bits, weight, expected_scales):
         ),
     ],
 )
-def test_quantize_weight_rtn(bits, weight, expected_quantized_weight):
-    scale = calculate_scales(weight, bits, symmetric=True, perchannel=True, clip_weights=False)
-    quantized_weight = quantize_weight_rtn(weight, scale, bits, symmetric=True)
+def test_weight_rtn_symmetric(bits, weight, expected_quantized_weight):
+    scales = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=False)
+    quantized_weight = quantize_weight_rtn(weight, scales, None, bits, symmetric=True)
+    assert torch.allclose(quantized_weight, expected_quantized_weight)
+
+
+@pytest.mark.quarot
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "bits, weight, expected_scales, expected_offsets",
+    [
+        (3, torch.tensor([[-4.0, 1.0, 2.0, 3.0]]), torch.tensor([[1.0]]), torch.tensor([4.0])),
+        (3, torch.tensor([[-1.0, 4.0, 5.0, 6.0]]), torch.tensor([[1.0]]), torch.tensor([1.0])),
+        (3, torch.tensor([[-0.5, 2.0, 2.5, 3.0]]), torch.tensor([[0.5]]), torch.tensor([1.0])),
+        (4, torch.tensor([[-2.0, 1.2, 2.3, 13.0]]), torch.tensor([[1.0]]), torch.tensor([2.0])),
+        (4, torch.tensor([[2.0, 5.2, 6.6, 7.5]]), torch.tensor([[0.5]]), torch.tensor([0.0])),
+    ],
+)
+def test_calculate_scales_asymmetric(bits, weight, expected_scales, expected_offsets):
+    scales, offsets = calculate_scales_asymmetric(weight, bits, perchannel=True)
+    assert torch.allclose(scales, expected_scales)
+    assert torch.allclose(offsets, expected_offsets)
+
+
+@pytest.mark.quarot
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "bits, weight, expected_quantized_weight",
+    [
+        (3, torch.tensor([[-4.0, 1.0, 2.0, 3.0]]), torch.tensor([[0.0, 5.0, 6.0, 7.0]])),
+        (3, torch.tensor([[-1.0, 4.0, 5.0, 6.0]]), torch.tensor([[0.0, 5.0, 6.0, 7.0]])),
+        (4, torch.tensor([[-2.0, 1.2, 2.3, 13.0]]), torch.tensor([[0.0, 3.0, 4.0, 15.0]])),
+        (4, torch.tensor([[2.0, 5.2, 6.6, 7.5]]), torch.tensor([[4.0, 10.0, 13.0, 15.0]])),
+    ],
+)
+def test_weight_rtn_asymmetric(bits, weight, expected_quantized_weight):
+    scale, offset = calculate_scales_asymmetric(weight, bits, perchannel=True)
+    quantized_weight = quantize_weight_rtn(weight, scale, offset, bits, symmetric=False)
+    assert torch.allclose(quantized_weight, expected_quantized_weight)
+
+
+@pytest.mark.quarot
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "bits, groupsize, weight, expected_scales, expected_offsets",
+    [
+        (3, 3, torch.tensor([[-4.0, 2.0, 3.0]]), torch.tensor([[1.0, 1.0, 1.0]]), torch.tensor([4.0, 4.0, 4.0])),
+        (
+            3,
+            3,
+            torch.tensor([[-4.0, 2.0, 3.0], [-2.0, 1.1, 1.5]]),
+            torch.tensor([[1.0, 1.0, 1.0], [0.5, 0.5, 0.5]]),
+            torch.tensor([[4.0, 4.0, 4.0], [4.0, 4.0, 4.0]]),
+        ),
+        (
+            4,
+            2,
+            torch.tensor([[-5.0, 2.5, 3.0, 15.0]]),
+            torch.tensor([[0.5, 0.5, 1.0, 1.0]]),
+            torch.tensor([10.0, 10.0, 0.0, 0.0]),
+        ),
+    ],
+)
+def test_calculate_scales_asymmetric_groupwise(bits, groupsize, weight, expected_scales, expected_offsets):
+    scales, offsets = calculate_scales_asymmetric(weight, bits, perchannel=True, groupsize=groupsize)
+    assert torch.allclose(scales, expected_scales)
+    assert torch.allclose(offsets, expected_offsets)
+
+
+@pytest.mark.quarot
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "bits, groupsize, weight, expected_quantized_weight",
+    [
+        (3, 3, torch.tensor([[-4.0, 2.0, 3.0]]), torch.tensor([[0.0, 6.0, 7.0]])),
+        (3, 3, torch.tensor([[-4.0, 2.0, 3.0], [-2.0, 1.1, 1.5]]), torch.tensor([[0.0, 6.0, 7.0], [0.0, 6.0, 7.0]])),
+        (4, 2, torch.tensor([[-5.0, 2.5, 3.0, 15.0]]), torch.tensor([[0.0, 15.0, 3.0, 15.0]])),
+    ],
+)
+def test_weight_rtn_asymmetric_groupwise(bits, groupsize, weight, expected_quantized_weight):
+    scale, offset = calculate_scales_asymmetric(weight, bits, perchannel=True, groupsize=groupsize)
+    quantized_weight = quantize_weight_rtn(weight, scale, offset, bits, symmetric=False)
     assert torch.allclose(quantized_weight, expected_quantized_weight)


### PR DESCRIPTION
KV cache quantization: reproduces Tables 10 and 11 to within 0.01 PPL -> i.e. working fully as expected.

Tested weight, activation and KV cache quantization i.e. end-to-end RTN: reproduces full 6- and 8-bit PPL results. For full 4-bit we get:

Llama-2 7B: 8.60 vs 8.37 in paper (i.e. 0.23 worse)
Llama-2 13B: 6.34 vs 6.09 in paper (i.e. 0.25 worse)

Given A16W4 was 0.1 PPL worse on 7 and 13B models I think there must be a minor bug somewhere in symmetric RTN (KV cache quantization uses asymmetric RTN). I have some ideas so will investigate.