### PR TITLE
QuaRot bugfixes

### DIFF
--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -235,7 +235,7 @@ def quarot_main(args: argparse.Namespace) -> None:
         # Rotate the model with fused Hadamard transformations.
         rotation.rotate_model(model_adapter, args.rotation_seed)
 
-    model_config = QuarotLlamaConfig.from_pretrained(args.model, dtype=config.dtype)
+    model_config = QuarotLlamaConfig.from_pretrained(args.model, dtype=config.dtype, use_cache=False)
     model_config._attn_implementation = "flash_attention_2"
     with transformers.modeling_utils.no_init_weights():
         # initialize quarot model

--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -192,7 +192,6 @@ def process_quarot_args(args):
     config.dtype = torch.float16
 
 
-@torch.no_grad()
 def quarot_main(args: argparse.Namespace) -> None:
     logging.info("Running QuaRot experiment.")
     logging.info(f"PyTorch device: {config.device}")
@@ -276,11 +275,11 @@ def quarot_main(args: argparse.Namespace) -> None:
         train_loader = data_utils.prepare_dataloader(
             dataset=dataset["train"], tokenizer=tokenizer, batch_size=args.ppl_eval_batch_size
         )
-        assert not args.w_asym, "Asymmetric quantization is not yet supported with QuaRot-GPTQ."
 
         quarot_model_adapter = LlamaModelAdapter(quarot_llama)
-        with torch.no_grad():
-            gptq.quantize_model_gptq(quarot_model_adapter, train_loader, bits=args.w_bits, symmetric=True)
+        gptq.quantize_model_gptq(
+            quarot_model_adapter, train_loader, bits=args.w_bits, symmetric=False if args.w_asym else True
+        )
         logging.info("Quantization complete.")
 
     quarot_llama.to(config.device)

--- a/src/quarot/nn/hadamard.py
+++ b/src/quarot/nn/hadamard.py
@@ -7,10 +7,10 @@ class OnlineHadamard(torch.nn.Module):
     def __init__(self, hadamard_dim, force_fp32=False):
         super().__init__()
         self.fp32_had = force_fp32
-        had_rem_dim = get_hadK(hadamard_dim)
-        self.register_buffer("had_rem_dim", had_rem_dim)
+        had_tensor = get_hadK(hadamard_dim)
+        self.register_buffer("had_tensor", had_tensor)
         if not self.fp32_had:
-            self.had_rem_dim = self.had_rem_dim.to(torch.float16)
+            self.had_tensor = self.had_tensor.to(torch.float16)
 
         if fht_available:
             self.had = _apply_fast_hadamard
@@ -22,7 +22,7 @@ class OnlineHadamard(torch.nn.Module):
         if self.fp32_had:
             x = x.float()
 
-        x = self.had(x, self.had_rem_dim)  # NB this uses a CUDA kernel from fast_hadamard_transform
+        x = self.had(x, self.had_tensor)  # NB this uses a CUDA kernel from fast_hadamard_transform
 
         x = x.to(x_dtype)
         return x

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -206,7 +206,7 @@ def quantize_module_rtn(
     scale, offset = calculate_scales(weight, bits, symmetric, clip_weights, vectorized=vectorized, groupsize=groupsize)
     quantized_weight = quantize_weight_rtn(weight, scale, offset, bits, symmetric)
 
-    module.weight.data = quantized_weight
+    module.weight.data = quantized_weight - offset if offset is not None else quantized_weight
     module.weight_scales = scale
 
 


### PR DESCRIPTION
- GPU OOM fix: flash attention forward pass should not _actually_ do KV caching, we emulate it by quantizing and immediately dequantizing the Ks and Vs.
- Various PPL mismatches: missing `symmetric` arg so always True by default caused some issues, and similar bugs

Added tests and lots of refactoring to GPTQ.