### PR TITLE
Add GPTQ

### DIFF
--- a/experiments/run_quarot.py
+++ b/experiments/run_quarot.py
@@ -96,6 +96,16 @@ def quarot_arg_parser(interactive: bool = True) -> argparse.Namespace:
         default=16,
         help='Number of bits to quantize the weights to.',
     )
+    parser.add_argument(
+        '--w-clip-vec',
+        action="store_true",
+        help='Vectorized weight clipping ratio search.',
+    )
+    parser.add_argument(
+        '--w-asym',
+        action="store_true",
+        help='Asymmetric weight quantization (else symmetric by default).',
+    )
 
     # Activation Quantization Arguments
     parser.add_argument(
@@ -247,7 +257,12 @@ def quarot_main(args: argparse.Namespace) -> None:
 
     if args.w_rtn:
         logging.info(f"Quantizing weights to INT{args.w_bits} using RTN.")
-        rtn.quantize_model_rtn(quarot_llama, bits=args.w_bits)
+        rtn.quantize_model_rtn(
+            quarot_llama,
+            bits=args.w_bits,
+            symmetric=False if args.w_asym else True,
+            vectorized=True if args.w_clip_vec else False,
+        )
         logging.info("Quantization complete.")
 
     quarot_llama.to(config.device)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,14 @@ dependencies = [
     "accelerate",
     "datasets==2.14.7",
     "einops",
-    "huggingface-hub==0.20.2",
+    "huggingface-hub==0.23.0",
     "lm-eval==0.4.1",
     "ml-collections",
     "numpy",
     "sentencepiece",
     "torch",
     "tqdm",
-    "transformers==4.37",
+    "transformers==4.41",
     "wandb",
 ]
 

--- a/src/quarot/gptq_utils.py
+++ b/src/quarot/gptq_utils.py
@@ -1,0 +1,176 @@
+import logging
+
+import torch
+import tqdm
+
+from slicegpt.rotate import get_layer0_inputs
+from slicegpt.utils import cleanup_memory, map_tensors
+
+
+def quantize_weight_gptq(W, H, max_blocksize=128, percdamp=0.01, groupsize=None):
+    num_features, num_columns = W.shape
+
+    if groupsize is None:
+        scale, offset = ...  # self.quantizer.find_params(W)
+
+    # find dead weights and set them to zero, and their Hess value to 1
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    W[:, dead] = 0
+
+    # add damping to the diagonal
+    H.diagonal().add_(percdamp * torch.mean(torch.diag(H)))
+
+    # calculate the inverse layer Hessian (Cholesky form)
+    L = torch.linalg.cholesky(H)
+    H_inv = torch.cholesky_inverse(L)
+    L_inv_transpose = torch.linalg.cholesky(H_inv, upper=True)
+
+    Q = torch.zeros_like(W)
+    for block_start_idx in range(0, num_columns, max_blocksize):
+        block_end_idx = min(block_start_idx + max_blocksize, num_columns)
+        blocksize = block_end_idx - block_start_idx
+
+        Err_block = torch.zeros((W.shape[0], blocksize))
+
+        for i in range(blocksize):
+            cur_idx = block_start_idx + i
+
+            if groupsize is not None and cur_idx % groupsize == 0:
+                scale, offset = ...  # self.quantizer.find_params(W[:, cur_idx:(cur_idx + groupsize)])
+
+            Q[:, cur_idx] = ...  # self.quantizer.quantize(W[:, cur_idx:cur_idx+1]).flatten()
+            # W_quantdequant = ...
+
+            Err_block[:, i] = (W[:, cur_idx] - Q[:, cur_idx]) / L_inv_transpose[cur_idx, cur_idx]
+            W[:, cur_idx:] -= Err_block[:, i : i + 1] * L_inv_transpose[cur_idx : cur_idx + 1, cur_idx:]
+
+        W[:, block_end_idx:] -= Err_block.matmul(L_inv_transpose[block_start_idx:block_end_idx, block_end_idx:])
+
+    return Q, scale, offset
+
+
+@torch.no_grad()
+def construct_hessian(X: list[torch.Tensor], ignore_masks: list[torch.Tensor] | None = None) -> torch.Tensor:
+    """
+    TODO.
+    """
+    # Run GC and cleanup GPU memory
+    cleanup_memory()
+    device = 'cuda'
+
+    H = None
+    for idx, X_batch in enumerate(X):
+        if ignore_masks:
+            X_batch[ignore_masks[idx] == 0] = 0
+
+        X_batch = X_batch.double().to(device=device)
+        H_batch = torch.sum(X_batch.mT @ X_batch, dim=0)  # sum over the batch dimension.
+        H = H_batch if H is None else H + H_batch
+
+    return H
+
+
+def get_signals(
+    layer_adapter: LayerAdapter, layer_args: list[tuple], layer_kwargs: list[dict[str, Any]]
+) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor], list[torch.Tensor], list[torch.Tensor]]:
+    """
+    Take the input signals ("activations") for a layer, run the layer forward.
+    Return the output of the layer (not layernormed) and the input to the MLP (pre-layernorm).
+    """
+    qkv_inputs, o_proj_inputs, upgate_inputs, down_proj_inputs = [], [], [], []
+    outputs = []
+    device = 'cuda'
+    layer_adapter.layer.to(device)
+
+    def make_hook(storage_list):
+        def hook_fn(_, args: tuple, _output: Any) -> None:
+            storage_list.append(args[0].cpu())
+
+        return hook_fn
+
+    hooks = [make_hook(qkv_inputs), make_hook(o_proj_inputs), make_hook(upgate_inputs), make_hook(down_proj_inputs)]
+    modules = [
+        layer_adapter.get_attn_inputs()[0],
+        layer_adapter.get_attn_output(),
+        layer_adapter.get_mlp_inputs()[0],
+        layer_adapter.get_mlp_output(),
+    ]
+    hooks = [m.register_forward_hook(h) for m, h in zip(modules, hooks)]
+
+    for layer_args_batch, layer_kwargs_batch in zip(layer_args, layer_kwargs):
+        layer_args_batch, layer_kwargs_batch = map_tensors([layer_args_batch, layer_kwargs_batch], device=device)
+        out = layer_adapter.layer(*layer_args_batch, **layer_kwargs_batch)
+        if isinstance(out, tuple):
+            out = out[layer_adapter.hidden_states_output_position]
+        out = out.cpu()
+        outputs.append(out)
+
+    [h.remove() for h in hooks]
+    return qkv_inputs, o_proj_inputs, upgate_inputs, down_proj_inputs, outputs
+
+
+@torch.no_grad()
+def quantize_model_gptq(
+    model_adapter: ModelAdapter,
+    dataloader: torch.utils.data.DataLoader[torch.Tensor],
+    apply_mask: bool = True,
+) -> None:
+    """
+    #TODO
+
+    This method works for models where the MLP block is computed after the attention block.
+    """
+    model_adapter.model.eval()
+    dtype = next(iter(model_adapter.model.parameters())).dtype
+
+    inps, args, kwargs, ignore_masks = [], [], [], []
+    for batch in dataloader:
+        inp_batch, args_batch, kwargs_batch = get_layer0_inputs(model_adapter, batch)
+        inps.append(inp_batch)
+        args.append(args_batch)
+        kwargs.append(kwargs_batch)
+        if apply_mask:
+            ignore_masks.append(batch["attention_mask"])
+
+    layers = model_adapter.get_layers()
+
+    logging.info("Quantizing model with GPTQ")
+    for idx, layer_adapter in enumerate(tqdm(layers, unit="layer", desc="Quantizing layer")):
+        layer = layer_adapter.layer
+
+        # get all activations for the current layer (4 sets)
+        qkv_inputs, o_proj_inputs, upgate_inputs, down_proj_inputs, outputs = get_signals(layer_adapter, args, kwargs)
+
+        # compute the 4 Hessians [construct_hessian(inps, ignore_masks)  # TODO: rescale?]
+        H_qkv, H_o_proj, H_upgate, H_down_proj = [
+            construct_hessian(X, ignore_masks) for X in [qkv_inputs, o_proj_inputs, upgate_inputs, down_proj_inputs]
+        ]
+
+        # get 4 weight matrices (concat as needed)
+        W_qkv = torch.cat([w.weight.data for w in layer_adapter.get_attn_inputs()], dim=0)
+        W_o_proj = layer_adapter.get_attn_output().weight.data
+        W_upgate = torch.cat([w.weight.data for w in layer_adapter.get_mlp_inputs()], dim=0)
+        W_down_proj = layer_adapter.get_mlp_output().weight.data
+
+        # 4 calls to quantizer
+        Q_qkv, scale_qkv, offset_qkv = quantize_weight_gptq(W_qkv, H_qkv)
+        Q_o_proj, scale_o_proj, offset_o_proj = quantize_weight_gptq(W_o_proj, H_o_proj)
+        Q_upgate, scale_upgate, offset_upgate = quantize_weight_gptq(W_upgate, H_upgate)
+        Q_down_proj, scale_down_proj, offset_down_proj = quantize_weight_gptq(W_down_proj, H_down_proj)
+
+        # Unconcatenate the qkv and upgate quantized weights, scales and offsets
+        for module in layer_adapter.get_attn_inputs():
+            out_features = module.weight.data.shape[0]
+            module.weight.data = Q_qkv[:out_features]
+            module.weight_scales = scale_qkv[:out_features]
+            module.weight_offsets = offset_qkv[:out_features]
+
+            Q_qkv = Q_qkv[out_features:]
+            scale_qkv = scale_qkv[out_features:]
+            offset_qkv = offset_qkv[out_features:]
+
+        # inps = outs
+        # cleanup_memory() ?
+
+    logging.info("Quantizing model with GPTQ done.")

--- a/src/quarot/modeling_llama.py
+++ b/src/quarot/modeling_llama.py
@@ -148,14 +148,10 @@ class QuarotFP16LlamaFlashAttention2(LlamaFlashAttention2):
             bsz, q_len, self.num_key_value_heads, self.head_dim
         )  # QuaRot: remove transpose
 
-        # QuaRot: shape is now shape[1] instead of shape[-2]
-        kv_seq_len = key_states.shape[1]
-        if past_key_value is not None:
-            kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
-        cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+        cos, sin = self.rotary_emb(value_states, position_ids)
         query_states, key_states = apply_rotary_pos_emb(
-            query_states, key_states, cos, sin, position_ids, unsqueeze_dim=2
-        )
+            query_states, key_states, cos, sin, unsqueeze_dim=2
+        )  # QuaRot: requires unsqueeze
 
         # QuaRot: apply online hadamard to queries and keys
         if self.online_had:

--- a/src/quarot/nn/hadamard.py
+++ b/src/quarot/nn/hadamard.py
@@ -7,10 +7,10 @@ class OnlineHadamard(torch.nn.Module):
     def __init__(self, hadamard_dim, force_fp32=False):
         super().__init__()
         self.fp32_had = force_fp32
-        had_rem_dim = get_hadK(hadamard_dim)
-        self.register_buffer("had_rem_dim", had_rem_dim)
+        had_tensor = get_hadK(hadamard_dim)
+        self.register_buffer("had_tensor", had_tensor)
         if not self.fp32_had:
-            self.had_rem_dim = self.had_rem_dim.to(torch.float16)
+            self.had_tensor = self.had_tensor.to(torch.float16)
 
         if fht_available:
             self.had = _apply_fast_hadamard
@@ -22,7 +22,7 @@ class OnlineHadamard(torch.nn.Module):
         if self.fp32_had:
             x = x.float()
 
-        x = self.had(x, self.had_rem_dim)  # NB this uses a CUDA kernel from fast_hadamard_transform
+        x = self.had(x, self.had_tensor)  # NB this uses a CUDA kernel from fast_hadamard_transform
 
         x = x.to(x_dtype)
         return x

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -206,7 +206,7 @@ def quantize_module_rtn(
     scale, offset = calculate_scales(weight, bits, symmetric, clip_weights, vectorized=vectorized, groupsize=groupsize)
     quantized_weight = quantize_weight_rtn(weight, scale, offset, bits, symmetric)
 
-    module.weight.data = quantized_weight
+    module.weight.data = quantized_weight - offset if offset is not None else quantized_weight
     module.weight_scales = scale
 
 

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -76,8 +76,8 @@ def calculate_scales(
 
     if clip_weights:
         # Perform a grid search to find the best weight scales according to quantization error.
-        max_shrink_factor = 0.20
-        n_steps = int(10 * (max_shrink_factor)) + 1
+        max_shrink_factor = 0.80
+        n_steps = int(100 * (max_shrink_factor)) + 1
         error_norm = 2.4
         shrink_factors = torch.linspace(1.0, 1 - max_shrink_factor, n_steps).to(weight.device)
 

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -119,7 +119,7 @@ def calculate_scales(
 
         else:
             best_quantization_error = torch.full(
-                (weight.shape[0],), float("inf"), device=weight.device, dtype=torch.float16
+                (weight.shape[0],), float("inf"), device=weight.device, dtype=weight.dtype
             )
             for i in range(n_steps):
                 shrink_factor = shrink_factors[i]
@@ -177,8 +177,8 @@ def quantize_weight_rtn(
     offset = offset.cuda() if offset is not None else None
 
     min_int, max_int = calculate_min_max_int(bits, symmetric)
-    min_int = min_int.to(device=weight.device)
-    max_int = max_int.to(device=weight.device)
+    min_int = min_int.to(device=weight.device, dtype=weight.dtype)
+    max_int = max_int.to(device=weight.device, dtype=weight.dtype)
     if symmetric:
         quantized_weight = torch.clamp(torch.round(weight / scale), min_int, max_int)
     else:

--- a/src/quarot/rtn.py
+++ b/src/quarot/rtn.py
@@ -40,21 +40,40 @@ def calculate_min_max_weight(
     return min_weight, max_weight
 
 
-def calculate_scales_symmetric(
-    weight: torch.Tensor, bits: int, perchannel: bool = True, clip_weights: bool = True, vectorized: bool = True
-) -> torch.Tensor:
+def calculate_scales(
+    weight: torch.Tensor,
+    bits: int,
+    symmetric: bool,
+    perchannel: bool = True,
+    clip_weights: bool = False,
+    vectorized: bool = True,
+    clip_ratio: float = 1.0,
+    groupsize: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
     """
-    Calculate the scales for symmetric quantization of a weight tensor to INT<bits> using the Round-to-Nearest scheme. If clip_weights is True,
-    the scales are found using a grid search to minimize the quantization error.
+    Calculate the scales (and offsets if asymmetric) for quantizing a weight tensor to INT<bits> using the Round-to-Nearest scheme.
     """
     device = weight.device
     weight = weight.cuda()
-    _, max_weight = calculate_min_max_weight(weight, symmetric=True, perchannel=perchannel)
-    _, max_int = calculate_min_max_int(bits, symmetric=True)
 
-    # Calculate the scales
+    if groupsize:
+        init_shape = weight.shape
+        weight = weight.reshape(-1, weight.shape[-2], weight.shape[-1] // groupsize, groupsize)
+
+    min_weight, max_weight = calculate_min_max_weight(weight, symmetric=symmetric, perchannel=perchannel)
+    min_weight *= clip_ratio
+    max_weight *= clip_ratio
+
+    _, max_int = calculate_min_max_int(bits, symmetric=symmetric)
     max_int = max_int.to(device=weight.device)
-    scale = max_weight / max_int
+
+    # Calculate scales and offsets
+    if symmetric:
+        scale = max_weight / max_int
+        offset = None
+    else:
+        scale = (max_weight - min_weight) / max_int
+        offset = torch.round(-min_weight / scale)
 
     if clip_weights:
         # Perform a grid search to find the best weight scales according to quantization error.
@@ -66,71 +85,75 @@ def calculate_scales_symmetric(
         if vectorized:
             # This vectorized implementation gives OOM for Llama-2 70B.
             candidate_max_weights = shrink_factors * max_weight
+            candidate_min_weights = shrink_factors * min_weight
 
-            candidate_scales = candidate_max_weights / max_int
+            if symmetric:
+                candidate_scales = candidate_max_weights / max_int
+                candidate_offset = None
+            else:
+                candidate_scales = (candidate_max_weights - candidate_min_weights) / max_int
+                candidate_offset = torch.round(-candidate_min_weights / candidate_scales)
+
             candidate_scales = candidate_scales.unsqueeze(1)
+            if not symmetric:
+                candidate_offset = candidate_offset.unsqueeze(1)
+
             weight = weight.unsqueeze(-1)
 
             # Quantize weights
-            candidate_quantized_weights = quantize_weight_rtn(weight, candidate_scales, None, bits, symmetric=True)
+            candidate_quantized_weights = quantize_weight_rtn(
+                weight, candidate_scales, candidate_offset, bits, symmetric=symmetric
+            )
 
             # Dequantize weights
-            reconstructed_weights = candidate_quantized_weights * candidate_scales
+            if symmetric:
+                reconstructed_weights = candidate_quantized_weights * candidate_scales
+            else:
+                reconstructed_weights = (candidate_quantized_weights - offset) * candidate_scales
 
-            # Compute quantization error and find the best scale for each weight
+            # Compute quantization error and find the best scale (and offset if asymmetric) for each weight
             quantization_errors = torch.sum(torch.abs(reconstructed_weights - weight).pow_(error_norm), 1)
-            best_scale_indices = torch.argmin(quantization_errors, dim=-1)
-            scale = torch.gather(candidate_scales.squeeze(1), 1, best_scale_indices.unsqueeze(1))
+            best_idx = torch.argmin(quantization_errors, dim=-1)
+            scale = torch.gather(candidate_scales.squeeze(1), 1, best_idx.unsqueeze(1))
+            if not symmetric:
+                offset = torch.gather(candidate_offset.squeeze(1), 1, best_idx.unsqueeze(1))
 
         else:
-            best_quantization_error = torch.full((weight.shape[0],), float("inf"), device=weight.device)
+            best_quantization_error = torch.full(
+                (weight.shape[0],), float("inf"), device=weight.device, dtype=torch.float16
+            )
             for i in range(n_steps):
                 shrink_factor = shrink_factors[i]
                 candidate_max_weight = shrink_factor * max_weight
-                candidate_scale = candidate_max_weight / max_int
+                candidate_min_weight = shrink_factor * min_weight
+
+                if symmetric:
+                    candidate_scale = candidate_max_weight / max_int
+                    candidate_offset = None
+                else:
+                    candidate_scale = (candidate_max_weight - candidate_min_weight) / max_int
+                    candidate_offset = torch.round(-candidate_min_weight / candidate_scale)
 
                 # Quantize weights
-                candidate_quantized_weight = quantize_weight_rtn(weight, candidate_scale, None, bits, symmetric=True)
+                candidate_quantized_weight = quantize_weight_rtn(
+                    weight, candidate_scale, candidate_offset, bits, symmetric=symmetric
+                )
 
                 # Dequantize weights
-                reconstructed_weight = candidate_quantized_weight * candidate_scale
+                if symmetric:
+                    reconstructed_weight = candidate_quantized_weight * candidate_scale
+                else:
+                    reconstructed_weight = (candidate_quantized_weight - candidate_offset) * candidate_scale
 
-                # Compute quantization error
+                # Compute quantization error and find the best scale (and offset if asymmetric)
                 quantization_error = torch.sum(torch.abs(reconstructed_weight - weight).pow_(error_norm), 1)
-
                 if i == 0 or torch.any(quantization_error < best_quantization_error):
                     improved_idx = torch.where(quantization_error < best_quantization_error)
                     scale[improved_idx] = candidate_scale[improved_idx]
+                    if not symmetric:
+                        offset[improved_idx] = candidate_offset[improved_idx]
+
                     best_quantization_error[improved_idx] = quantization_error[improved_idx]
-
-    weight = weight.to(device)
-    scale = scale.to(device)
-
-    return scale
-
-
-def calculate_scales_asymmetric(
-    weight: torch.Tensor, bits: int, perchannel: bool = True, clip_ratio: float = 1.0, groupsize: int | None = None
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    Calculate the scales and offsets for asymmetric quantization a weight tensor to INT<bits> using the Round-to-Nearest scheme.
-    """
-    device = weight.device
-    weight = weight.cuda()
-
-    if groupsize:
-        init_shape = weight.shape
-        weight = weight.reshape(-1, weight.shape[-2], weight.shape[-1] // groupsize, groupsize)
-
-    min_weight, max_weight = calculate_min_max_weight(weight, symmetric=False, perchannel=perchannel)
-    min_weight *= clip_ratio
-    max_weight *= clip_ratio
-
-    _, max_int = calculate_min_max_int(bits, symmetric=False)
-
-    # Calculate scales and offsets
-    scale = (max_weight - min_weight) / max_int
-    offset = torch.round(-min_weight / scale)
 
     if groupsize:
         scale = scale.repeat(1, 1, 1, groupsize).reshape(init_shape)
@@ -138,7 +161,8 @@ def calculate_scales_asymmetric(
 
     weight = weight.to(device)
     scale = scale.to(device)
-    offset = offset.to(device)
+    offset = offset.to(device) if offset is not None else None
+
     return scale, offset
 
 
@@ -151,6 +175,7 @@ def quantize_weight_rtn(
     device = weight.device
     weight = weight.cuda()
     scale = scale.cuda()
+    offset = offset.cuda() if offset is not None else None
 
     min_int, max_int = calculate_min_max_int(bits, symmetric)
     min_int = min_int.to(device=weight.device)
@@ -169,7 +194,6 @@ def quantize_module_rtn(
     module: QuarotFP16Linear,
     bits: int,
     symmetric: bool = True,
-    perchannel: bool = True,
     clip_weights: bool = True,
     groupsize: int | None = None,
 ) -> None:
@@ -178,12 +202,8 @@ def quantize_module_rtn(
     scales are stored in the module's weight_scales buffer, and are also stored in torch.float16.
     """
     weight = module.weight
-    offset = None
-    if symmetric:
-        scale = calculate_scales_symmetric(weight, bits, perchannel, clip_weights)
-    else:
-        scale, offset = calculate_scales_asymmetric(weight, bits, perchannel, groupsize)
 
+    scale, offset = calculate_scales(weight, bits, symmetric, clip_weights, vectorized=True, groupsize=groupsize)
     quantized_weight = quantize_weight_rtn(weight, scale, offset, bits, symmetric)
 
     module.weight.data = quantized_weight
@@ -194,7 +214,6 @@ def quantize_model_rtn(
     model,
     bits: int,
     symmetric: bool = True,
-    perchannel: bool = True,
     clip_weights: bool = True,
     groupsize: int | None = None,
 ) -> None:
@@ -205,15 +224,14 @@ def quantize_model_rtn(
         model: the model to quantize
         bits: the number of bits to quantize the weights to
         symmetric: whether to use symmetric quantization
-        perchannel: whether to use per-channel quantization
         clip_weights: whether to clip the weights to the maximum representable value
     """
     layers = model.model.layers
     for layer in tqdm(layers, desc="Quantizing layers", unit="layer"):
-        quantize_module_rtn(layer.mlp.up_proj, bits, symmetric, perchannel, clip_weights, groupsize)
-        quantize_module_rtn(layer.mlp.gate_proj, bits, symmetric, perchannel, clip_weights, groupsize)
-        quantize_module_rtn(layer.mlp.down_proj, bits, symmetric, perchannel, clip_weights, groupsize)
-        quantize_module_rtn(layer.self_attn.q_proj, bits, symmetric, perchannel, clip_weights, groupsize)
-        quantize_module_rtn(layer.self_attn.k_proj, bits, symmetric, perchannel, clip_weights, groupsize)
-        quantize_module_rtn(layer.self_attn.v_proj, bits, symmetric, perchannel, clip_weights, groupsize)
-        quantize_module_rtn(layer.self_attn.o_proj, bits, symmetric, perchannel, clip_weights, groupsize)
+        quantize_module_rtn(layer.mlp.up_proj, bits, symmetric, clip_weights, groupsize)
+        quantize_module_rtn(layer.mlp.gate_proj, bits, symmetric, clip_weights, groupsize)
+        quantize_module_rtn(layer.mlp.down_proj, bits, symmetric, clip_weights, groupsize)
+        quantize_module_rtn(layer.self_attn.q_proj, bits, symmetric, clip_weights, groupsize)
+        quantize_module_rtn(layer.self_attn.k_proj, bits, symmetric, clip_weights, groupsize)
+        quantize_module_rtn(layer.self_attn.v_proj, bits, symmetric, clip_weights, groupsize)
+        quantize_module_rtn(layer.self_attn.o_proj, bits, symmetric, clip_weights, groupsize)

--- a/tests/test_gptq.py
+++ b/tests/test_gptq.py
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pytest
+import torch
+
+from quarot.gptq import quantize_weight_gptq
+
+
+@pytest.mark.quarot
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "bits, weight, hessian, expected_quantized_weight, expected_scale",
+    [
+        (
+            4,
+            torch.tensor([[1.1, -2.3, 3.5], [-1.5, 2.6, -7.0]]),
+            torch.eye(3, 3),
+            torch.tensor([[2.0, -5.0, 7.0], [-2.0, 3.0, -7.0]]),
+            torch.tensor([[0.5], [1.0]]),
+        ),
+    ],
+)
+def test_weight_gptq(bits, weight, hessian, expected_quantized_weight, expected_scale):
+    quantized_weight, scale = quantize_weight_gptq(weight, hessian, bits, percdamp=0.0, clip_weights=False)
+    assert torch.allclose(scale, expected_scale)
+    assert torch.allclose(quantized_weight, expected_quantized_weight)

--- a/tests/test_gptq.py
+++ b/tests/test_gptq.py
@@ -6,8 +6,6 @@ import torch
 
 from quarot.gptq import quantize_weight_gptq
 
-torch.set_default_dtype(torch.float16)
-
 
 @pytest.mark.quarot
 @pytest.mark.gpu
@@ -16,10 +14,10 @@ torch.set_default_dtype(torch.float16)
     [
         (
             4,
-            torch.tensor([[1.1, -2.3, 3.5], [-1.5, 2.6, -7.0]]),
-            torch.eye(3, 3, dtype=torch.float32),
-            torch.tensor([[2.0, -5.0, 7.0], [-2.0, 3.0, -7.0]]),
-            torch.tensor([[0.5], [1.0]]),
+            torch.tensor([[1.1, -2.3, 3.5], [-1.5, 2.6, -7.0]], dtype=torch.float16),
+            torch.eye(3, 3),
+            torch.tensor([[2.0, -5.0, 7.0], [-2.0, 3.0, -7.0]], dtype=torch.float16),
+            torch.tensor([[0.5], [1.0]], dtype=torch.float16),
         ),
     ],
 )

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -38,6 +38,6 @@ def test_act_quantizer():
     assert quantized_act.shape == (batch_size, seq_len, hidden_dim)
     assert act_scales.shape == (batch_size, seq_len, 1)
 
-    # Check quantization error
+    # Check quantization error (NB: flakey, depends on randomness of act)
     dequantized_act = quantized_act * act_scales
     assert torch.allclose(act, dequantized_act, rtol=1e-2, atol=1e-2)

--- a/tests/test_rtn.py
+++ b/tests/test_rtn.py
@@ -4,7 +4,9 @@
 import pytest
 import torch
 
-from quarot.rtn import calculate_scales_asymmetric, calculate_scales_symmetric, quantize_weight_rtn
+from quarot.rtn import calculate_scales, quantize_weight_rtn
+
+torch.set_default_dtype(torch.float16)
 
 
 @pytest.mark.quarot
@@ -23,11 +25,18 @@ from quarot.rtn import calculate_scales_asymmetric, calculate_scales_symmetric, 
     ],
 )
 def test_calculate_scales_symmetric(bits, weight, expected_scales):
-    scales = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=False, vectorized=False)
+    symmetric = True
+    scales, offsets = calculate_scales(weight, bits, symmetric=symmetric, clip_weights=False, vectorized=False)
     assert torch.allclose(scales, expected_scales)
-    scales_nonvec = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=True, vectorized=False)
-    scales_vec = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=True, vectorized=True)
+    assert offsets is None
+
+    scales_nonvec, offsets_nonvec = calculate_scales(
+        weight, bits, symmetric=symmetric, clip_weights=True, vectorized=False
+    )
+    scales_vec, offsets_vec = calculate_scales(weight, bits, symmetric=symmetric, clip_weights=True, vectorized=True)
     assert torch.allclose(scales_vec, scales_nonvec)
+    assert offsets_nonvec is None
+    assert offsets_vec is None
 
 
 @pytest.mark.quarot
@@ -45,13 +54,17 @@ def test_calculate_scales_symmetric(bits, weight, expected_scales):
     ],
 )
 def test_weight_rtn_symmetric(bits, weight, expected_quantized_weight):
-    scales = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=False)
-    quantized_weight = quantize_weight_rtn(weight, scales, None, bits, symmetric=True)
+    symmetric = True
+    scales, offsets = calculate_scales(weight, bits, symmetric=symmetric, clip_weights=False)
+    quantized_weight = quantize_weight_rtn(weight, scales, offsets, bits, symmetric=symmetric)
     assert torch.allclose(quantized_weight, expected_quantized_weight)
-    scales_nonvec = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=True, vectorized=False)
-    scales_vec = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=True, vectorized=True)
-    quantized_weight_nonvec = quantize_weight_rtn(weight, scales_nonvec, None, bits, symmetric=True)
-    quantized_weight_vec = quantize_weight_rtn(weight, scales_vec, None, bits, symmetric=True)
+
+    scales_nonvec, offsets_nonvec = calculate_scales(
+        weight, bits, symmetric=symmetric, clip_weights=True, vectorized=False
+    )
+    scales_vec, offsets_vec = calculate_scales(weight, bits, symmetric=symmetric, clip_weights=True, vectorized=True)
+    quantized_weight_nonvec = quantize_weight_rtn(weight, scales_nonvec, offsets_nonvec, bits, symmetric=symmetric)
+    quantized_weight_vec = quantize_weight_rtn(weight, scales_vec, offsets_vec, bits, symmetric=symmetric)
     assert torch.allclose(quantized_weight_vec, quantized_weight_nonvec)
 
 
@@ -68,9 +81,17 @@ def test_weight_rtn_symmetric(bits, weight, expected_quantized_weight):
     ],
 )
 def test_calculate_scales_asymmetric(bits, weight, expected_scales, expected_offsets):
-    scales, offsets = calculate_scales_asymmetric(weight, bits, perchannel=True)
+    symmetric = False
+    scales, offsets = calculate_scales(weight, bits, symmetric=symmetric, clip_weights=False)
     assert torch.allclose(scales, expected_scales)
     assert torch.allclose(offsets, expected_offsets)
+
+    scales_nonvec, offsets_nonvec = calculate_scales(
+        weight, bits, symmetric=symmetric, clip_weights=True, vectorized=False
+    )
+    scales_vec, offsets_vec = calculate_scales(weight, bits, symmetric=symmetric, clip_weights=True, vectorized=True)
+    assert torch.allclose(scales_vec, scales_nonvec)
+    assert torch.allclose(offsets_nonvec, offsets_vec)
 
 
 @pytest.mark.quarot
@@ -85,9 +106,18 @@ def test_calculate_scales_asymmetric(bits, weight, expected_scales, expected_off
     ],
 )
 def test_weight_rtn_asymmetric(bits, weight, expected_quantized_weight):
-    scale, offset = calculate_scales_asymmetric(weight, bits, perchannel=True)
-    quantized_weight = quantize_weight_rtn(weight, scale, offset, bits, symmetric=False)
+    symmetric = False
+    scale, offset = calculate_scales(weight, bits, symmetric=symmetric, clip_weights=False)
+    quantized_weight = quantize_weight_rtn(weight, scale, offset, bits, symmetric=symmetric)
     assert torch.allclose(quantized_weight, expected_quantized_weight)
+
+    scales_nonvec, offsets_nonvec = calculate_scales(
+        weight, bits, symmetric=symmetric, clip_weights=True, vectorized=False
+    )
+    scales_vec, offsets_vec = calculate_scales(weight, bits, symmetric=symmetric, clip_weights=True, vectorized=True)
+    quantized_weight_nonvec = quantize_weight_rtn(weight, scales_nonvec, offsets_nonvec, bits, symmetric=symmetric)
+    quantized_weight_vec = quantize_weight_rtn(weight, scales_vec, offsets_vec, bits, symmetric=symmetric)
+    assert torch.allclose(quantized_weight_vec, quantized_weight_nonvec)
 
 
 @pytest.mark.quarot
@@ -113,7 +143,7 @@ def test_weight_rtn_asymmetric(bits, weight, expected_quantized_weight):
     ],
 )
 def test_calculate_scales_asymmetric_groupwise(bits, groupsize, weight, expected_scales, expected_offsets):
-    scales, offsets = calculate_scales_asymmetric(weight, bits, perchannel=True, groupsize=groupsize)
+    scales, offsets = calculate_scales(weight, bits, symmetric=False, clip_weights=False, groupsize=groupsize)
     assert torch.allclose(scales, expected_scales)
     assert torch.allclose(offsets, expected_offsets)
 
@@ -129,6 +159,7 @@ def test_calculate_scales_asymmetric_groupwise(bits, groupsize, weight, expected
     ],
 )
 def test_weight_rtn_asymmetric_groupwise(bits, groupsize, weight, expected_quantized_weight):
-    scale, offset = calculate_scales_asymmetric(weight, bits, perchannel=True, groupsize=groupsize)
+    expected_quantized_weight = expected_quantized_weight.to(dtype=torch.float16)
+    scale, offset = calculate_scales(weight, bits, symmetric=False, clip_weights=False, groupsize=groupsize)
     quantized_weight = quantize_weight_rtn(weight, scale, offset, bits, symmetric=False)
     assert torch.allclose(quantized_weight, expected_quantized_weight)

--- a/tests/test_rtn.py
+++ b/tests/test_rtn.py
@@ -23,8 +23,11 @@ from quarot.rtn import calculate_scales_asymmetric, calculate_scales_symmetric, 
     ],
 )
 def test_calculate_scales_symmetric(bits, weight, expected_scales):
-    scales = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=False)
+    scales = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=False, vectorized=False)
     assert torch.allclose(scales, expected_scales)
+    scales_nonvec = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=True, vectorized=False)
+    scales_vec = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=True, vectorized=True)
+    assert torch.allclose(scales_vec, scales_nonvec)
 
 
 @pytest.mark.quarot
@@ -45,6 +48,11 @@ def test_weight_rtn_symmetric(bits, weight, expected_quantized_weight):
     scales = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=False)
     quantized_weight = quantize_weight_rtn(weight, scales, None, bits, symmetric=True)
     assert torch.allclose(quantized_weight, expected_quantized_weight)
+    scales_nonvec = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=True, vectorized=False)
+    scales_vec = calculate_scales_symmetric(weight, bits, perchannel=True, clip_weights=True, vectorized=True)
+    quantized_weight_nonvec = quantize_weight_rtn(weight, scales_nonvec, None, bits, symmetric=True)
+    quantized_weight_vec = quantize_weight_rtn(weight, scales_vec, None, bits, symmetric=True)
+    assert torch.allclose(quantized_weight_vec, quantized_weight_nonvec)
 
 
 @pytest.mark.quarot


### PR DESCRIPTION
Experiments: 

E2E (symmetric weights, asymmetric acts and KV)
- A4W4KV4 GPTQ QuaRot ppl: 6.04 vs 6.10 in paper
- A6W6KV6 GPTQ QuaRot ppl: 5.52 vs 5.52 in paper
- A8W8KV8 GPTQ QuaRot ppl: 5.50 vs 5.50 in paper

Weight only, asymmetric
- W4 RTN ppl: 7.02 vs 6.99
- W4 GPTQ ppl: 9.62 vs 8.25 (both of these anomalous, should be at least better than RTN)
- W4 RTN QuaRot ppl: 6.87 vs 6.76
- W4 GPTQ QuaRot ppl: 5.61 vs 5.60

Weight only, symmetric
- W4 RTN ppl: 6.99
- W4 GPTQ ppl: NaN (??)
- W4 RTN QuaRot ppl: 6.85
- W4 GPTQ QuaRot ppl: 5.61